### PR TITLE
feat(T033): add per-diagram zoom/pan for Mermaid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- View メニュー: 拡大 (⌘+) / 縮小 (⌘-) / 実寸 (⌘0) で Markdown 本文を 50%〜200% にズーム (T032)
+
 ## [0.2.0] - 2026-04-21
 
 ### Added

--- a/docs/t033-mermaid-e2e.md
+++ b/docs/t033-mermaid-e2e.md
@@ -1,0 +1,52 @@
+# T033 Mermaid 個別ズーム E2E 用サンプル
+
+Mermaid を 2 個並べて、個別にズーム状態を持つことを確認する。
+
+## 1. シーケンス図
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI
+    participant Bun
+    participant WebView
+
+    User->>CLI: mado README.md
+    CLI->>Bun: spawn
+    Bun->>Bun: watch file
+    Bun->>WebView: open window
+    WebView->>Bun: ready
+    Bun->>WebView: state(content)
+    WebView->>WebView: render markdown + mermaid
+    loop file change
+        Bun->>WebView: state(updated content)
+    end
+```
+
+## 2. フローチャート
+
+```mermaid
+flowchart TD
+    A[CLI 入力] --> B{引数種別}
+    B -->|file| C[file watcher 起動]
+    B -->|url| D[URL fetch]
+    B -->|render| E[PNG 出力]
+    C --> F[WebSocket push]
+    D --> F
+    F --> G[WebView 表示]
+    E --> H[stdout に path]
+```
+
+## 3. クラス図（比較用に 3 個目）
+
+```mermaid
+classDiagram
+    class Window {
+      +open()
+      +close()
+    }
+    class Renderer {
+      +render(md)
+    }
+    Window --> Renderer
+```

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -756,6 +756,11 @@ async function main(): Promise<void> {
       }
     },
     openFileDialog: (opts) => Utils.openFileDialog(opts),
+    // View メニュー: WebView 側の __MADO_ZOOM_* を呼ぶ (T032)。
+    // ログは WebView 側 applyZoom が出すため Bun 側では二重記録しない。
+    zoomIn: () => win.webview.executeJavascript("window.__MADO_ZOOM_IN__()"),
+    zoomOut: () => win.webview.executeJavascript("window.__MADO_ZOOM_OUT__()"),
+    zoomReset: () => win.webview.executeJavascript("window.__MADO_ZOOM_RESET__()"),
   });
 
   // 10b'. 左ペインファイルエントリ用コンテキストメニューをインストール

--- a/src/bun/menu.test.ts
+++ b/src/bun/menu.test.ts
@@ -10,11 +10,15 @@ import {
   APP_MENU_LABEL,
   FILE_MENU_LABEL,
   EDIT_MENU_LABEL,
+  VIEW_MENU_LABEL,
   WINDOW_MENU_LABEL,
   FILE_OPEN_ACTION,
   FILE_OPEN_RECENT_ACTION,
   APP_PREFERENCES_ACTION,
   WINDOW_FOCUS_ACTION,
+  VIEW_ZOOM_IN_ACTION,
+  VIEW_ZOOM_OUT_ACTION,
+  VIEW_ZOOM_RESET_ACTION,
   ACCELERATOR_QUIT,
   ACCELERATOR_HIDE,
   ACCELERATOR_HIDE_OTHERS,
@@ -22,6 +26,9 @@ import {
   ACCELERATOR_OPEN,
   ACCELERATOR_CLOSE,
   ACCELERATOR_MINIMIZE,
+  ACCELERATOR_ZOOM_IN,
+  ACCELERATOR_ZOOM_OUT,
+  ACCELERATOR_ZOOM_RESET,
   buildApplicationMenu,
   dispatchMenuAction,
 } from "./menu";
@@ -33,6 +40,9 @@ function makeDeps(overrides: Partial<MenuDeps> = {}): MenuDeps {
     listWindows: () => [],
     focusWindowById: () => {},
     openFileDialog: async () => [],
+    zoomIn: () => {},
+    zoomOut: () => {},
+    zoomReset: () => {},
     ...overrides,
   };
 }
@@ -59,17 +69,19 @@ function findByRole(items: MenuItem[], role: string): MenuItem | undefined {
 }
 
 describe("buildApplicationMenu", () => {
-  test("4 つのトップレベルメニュー (mado / File / Edit / Window) を返す", () => {
+  test("5 つのトップレベルメニュー (mado / File / Edit / View / Window) を返す", () => {
     const menu = buildApplicationMenu(makeDeps());
-    expect(menu).toHaveLength(4);
+    expect(menu).toHaveLength(5);
     assertNormal(menu[0]!);
     assertNormal(menu[1]!);
     assertNormal(menu[2]!);
     assertNormal(menu[3]!);
+    assertNormal(menu[4]!);
     expect((menu[0] as { label?: string }).label).toBe(APP_MENU_LABEL);
     expect((menu[1] as { label?: string }).label).toBe(FILE_MENU_LABEL);
     expect((menu[2] as { label?: string }).label).toBe(EDIT_MENU_LABEL);
-    expect((menu[3] as { label?: string }).label).toBe(WINDOW_MENU_LABEL);
+    expect((menu[3] as { label?: string }).label).toBe(VIEW_MENU_LABEL);
+    expect((menu[4] as { label?: string }).label).toBe(WINDOW_MENU_LABEL);
   });
 
   test("Application メニューに role:quit + Cmd+Q accelerator がある", () => {
@@ -137,7 +149,7 @@ describe("buildApplicationMenu", () => {
 
   test("Window メニューに minimize / zoom / bringAllToFront の role が含まれる", () => {
     const menu = buildApplicationMenu(makeDeps());
-    const win = menu[3] as { submenu?: MenuItem[] };
+    const win = menu[4] as { submenu?: MenuItem[] };
     const minimize = findByRole(win.submenu!, "minimize");
     expect(minimize).toBeDefined();
     expect((minimize as { accelerator?: string }).accelerator).toBe(ACCELERATOR_MINIMIZE);
@@ -153,7 +165,7 @@ describe("buildApplicationMenu", () => {
       ],
     });
     const menu = buildApplicationMenu(deps);
-    const win = menu[3] as { submenu?: MenuItem[] };
+    const win = menu[4] as { submenu?: MenuItem[] };
     const sub = win.submenu!;
     const dynamicItems = sub.filter(
       (i) => (i as { action?: string }).action === WINDOW_FOCUS_ACTION,
@@ -169,7 +181,7 @@ describe("buildApplicationMenu", () => {
 
   test("listWindows() が 0 件なら動的項目は展開されない", () => {
     const menu = buildApplicationMenu(makeDeps());
-    const win = menu[3] as { submenu?: MenuItem[] };
+    const win = menu[4] as { submenu?: MenuItem[] };
     const dynamicItems = win.submenu!.filter(
       (i) => (i as { action?: string }).action === WINDOW_FOCUS_ACTION,
     );
@@ -227,6 +239,50 @@ describe("buildApplicationMenu > Edit メニュー", () => {
       "delete",
       "selectAll",
     ]);
+  });
+});
+
+describe("buildApplicationMenu > View メニュー", () => {
+  test("View メニューは menu[3] に存在し VIEW_MENU_LABEL を持つ", () => {
+    const menu = buildApplicationMenu(makeDeps());
+    const view = menu[3] as { label?: string; submenu?: MenuItem[] };
+    expect(view.label).toBe(VIEW_MENU_LABEL);
+    expect(view.submenu).toBeDefined();
+  });
+
+  test("View submenu に 拡大 / 縮小 / 実寸 が正しい順序で並び、action / accelerator が設定される", () => {
+    const menu = buildApplicationMenu(makeDeps());
+    const view = menu[3] as { submenu?: MenuItem[] };
+    const sub = view.submenu!;
+    expect(sub).toHaveLength(3);
+
+    const zoomIn = sub[0] as {
+      label?: string;
+      action?: string;
+      accelerator?: string;
+    };
+    const zoomOut = sub[1] as {
+      label?: string;
+      action?: string;
+      accelerator?: string;
+    };
+    const zoomReset = sub[2] as {
+      label?: string;
+      action?: string;
+      accelerator?: string;
+    };
+
+    expect(zoomIn.label).toBe("拡大");
+    expect(zoomIn.action).toBe(VIEW_ZOOM_IN_ACTION);
+    expect(zoomIn.accelerator).toBe(ACCELERATOR_ZOOM_IN);
+
+    expect(zoomOut.label).toBe("縮小");
+    expect(zoomOut.action).toBe(VIEW_ZOOM_OUT_ACTION);
+    expect(zoomOut.accelerator).toBe(ACCELERATOR_ZOOM_OUT);
+
+    expect(zoomReset.label).toBe("実寸");
+    expect(zoomReset.action).toBe(VIEW_ZOOM_RESET_ACTION);
+    expect(zoomReset.accelerator).toBe(ACCELERATOR_ZOOM_RESET);
   });
 });
 
@@ -301,6 +357,27 @@ describe("dispatchMenuAction", () => {
     });
     await dispatchMenuAction({ action: WINDOW_FOCUS_ACTION, data: {} }, deps);
     expect(focused).toEqual([]);
+  });
+
+  test("view:zoom-in → deps.zoomIn を呼ぶ", async () => {
+    let called = 0;
+    const deps = makeDeps({ zoomIn: () => called++ });
+    await dispatchMenuAction({ action: VIEW_ZOOM_IN_ACTION }, deps);
+    expect(called).toBe(1);
+  });
+
+  test("view:zoom-out → deps.zoomOut を呼ぶ", async () => {
+    let called = 0;
+    const deps = makeDeps({ zoomOut: () => called++ });
+    await dispatchMenuAction({ action: VIEW_ZOOM_OUT_ACTION }, deps);
+    expect(called).toBe(1);
+  });
+
+  test("view:zoom-reset → deps.zoomReset を呼ぶ", async () => {
+    let called = 0;
+    const deps = makeDeps({ zoomReset: () => called++ });
+    await dispatchMenuAction({ action: VIEW_ZOOM_RESET_ACTION }, deps);
+    expect(called).toBe(1);
   });
 
   test("未知 action は何もしない (例外を投げない)", async () => {

--- a/src/bun/menu.ts
+++ b/src/bun/menu.ts
@@ -17,6 +17,7 @@ export const FILE_MENU_LABEL = "File";
 // macOS は "Edit" というラベルを手掛かりに Emoji & Symbols 等を自動挿入するため
 // 英名 "Edit" を固定し、多言語化は別タスクで扱う。
 export const EDIT_MENU_LABEL = "Edit";
+export const VIEW_MENU_LABEL = "View";
 export const WINDOW_MENU_LABEL = "Window";
 
 // --- アクション識別子 ---
@@ -24,6 +25,9 @@ export const FILE_OPEN_ACTION = "file:open";
 export const FILE_OPEN_RECENT_ACTION = "file:open-recent";
 export const APP_PREFERENCES_ACTION = "app:preferences";
 export const WINDOW_FOCUS_ACTION = "window:focus";
+export const VIEW_ZOOM_IN_ACTION = "view:zoom-in";
+export const VIEW_ZOOM_OUT_ACTION = "view:zoom-out";
+export const VIEW_ZOOM_RESET_ACTION = "view:zoom-reset";
 
 // --- アクセラレータ (Electrobun は Swift 側へ文字列をそのまま渡す)。
 // GlobalShortcut.register の例に倣い "CommandOrControl+..." 記法を採用するが、
@@ -35,6 +39,11 @@ export const ACCELERATOR_PREFERENCES = "CommandOrControl+,";
 export const ACCELERATOR_OPEN = "CommandOrControl+O";
 export const ACCELERATOR_CLOSE = "CommandOrControl+W";
 export const ACCELERATOR_MINIMIZE = "CommandOrControl+M";
+// Cmd+"+" は Shift+"=" のため "=" で受ける (Electron/Chromium と同じ慣例)。
+// 動かない場合は "CommandOrControl+Plus" → "CommandOrControl+Equal" の順で試す。
+export const ACCELERATOR_ZOOM_IN = "CommandOrControl+=";
+export const ACCELERATOR_ZOOM_OUT = "CommandOrControl+-";
+export const ACCELERATOR_ZOOM_RESET = "CommandOrControl+0";
 
 // --- メニューラベル (role 既定値があるものはネイティブ側に任せるため未使用) ---
 const LABEL_PREFERENCES = "Preferences...";
@@ -74,6 +83,12 @@ export interface MenuDeps {
     canChooseDirectory?: boolean;
     allowsMultipleSelection?: boolean;
   }) => Promise<string[]>;
+  /** View > 拡大 (⌘+) ハンドラ。WebView 側の __MADO_ZOOM_IN__ を呼ぶ想定。 */
+  zoomIn: () => void;
+  /** View > 縮小 (⌘-) ハンドラ。WebView 側の __MADO_ZOOM_OUT__ を呼ぶ想定。 */
+  zoomOut: () => void;
+  /** View > 実寸 (⌘0) ハンドラ。WebView 側の __MADO_ZOOM_RESET__ を呼ぶ想定。 */
+  zoomReset: () => void;
 }
 
 /**
@@ -170,7 +185,31 @@ export function buildApplicationMenu(deps: MenuDeps): ApplicationMenuItemConfig[
     submenu: windowSubmenu,
   };
 
-  return [appMenu, fileMenu, editMenu, windowMenu];
+  // View メニュー: ⌘+/⌘-/⌘0 で .markdown-body を 50-200% ズーム (T032)。
+  // クリックハンドラは dispatchMenuAction → deps.zoomIn/Out/Reset を経由して
+  // WebView の __MADO_ZOOM_* グローバル関数に到達する。
+  const viewMenu: ApplicationMenuItemConfig = {
+    label: VIEW_MENU_LABEL,
+    submenu: [
+      {
+        label: "拡大",
+        action: VIEW_ZOOM_IN_ACTION,
+        accelerator: ACCELERATOR_ZOOM_IN,
+      },
+      {
+        label: "縮小",
+        action: VIEW_ZOOM_OUT_ACTION,
+        accelerator: ACCELERATOR_ZOOM_OUT,
+      },
+      {
+        label: "実寸",
+        action: VIEW_ZOOM_RESET_ACTION,
+        accelerator: ACCELERATOR_ZOOM_RESET,
+      },
+    ],
+  };
+
+  return [appMenu, fileMenu, editMenu, viewMenu, windowMenu];
 }
 
 /**
@@ -233,6 +272,19 @@ export async function dispatchMenuAction(
       return;
     }
     deps.focusWindowById(event.data.winId);
+    return;
+  }
+
+  if (event.action === VIEW_ZOOM_IN_ACTION) {
+    deps.zoomIn();
+    return;
+  }
+  if (event.action === VIEW_ZOOM_OUT_ACTION) {
+    deps.zoomOut();
+    return;
+  }
+  if (event.action === VIEW_ZOOM_RESET_ACTION) {
+    deps.zoomReset();
     return;
   }
 

--- a/src/lib/__tests__/mermaid-zoom.test.ts
+++ b/src/lib/__tests__/mermaid-zoom.test.ts
@@ -1,0 +1,199 @@
+/**
+ * mermaid-zoom.ts のユニットテスト (T033)。
+ *
+ * clampMermaidZoom / wheelDeltaToScaleFactor / refocusTranslate /
+ * nextMermaidZoomIn / nextMermaidZoomOut の境界値・不変条件を検証する。
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  MERMAID_ZOOM_MIN,
+  MERMAID_ZOOM_MAX,
+  MERMAID_ZOOM_STEP,
+  MERMAID_ZOOM_DEFAULT,
+  clampMermaidZoom,
+  wheelDeltaToScaleFactor,
+  refocusTranslate,
+  nextMermaidZoomIn,
+  nextMermaidZoomOut,
+} from "../mermaid-zoom";
+
+describe("定数", () => {
+  test("MIN / MAX / STEP / DEFAULT が仕様値", () => {
+    expect(MERMAID_ZOOM_MIN).toBe(0.5);
+    expect(MERMAID_ZOOM_MAX).toBe(4.0);
+    expect(MERMAID_ZOOM_STEP).toBe(0.1);
+    expect(MERMAID_ZOOM_DEFAULT).toBe(1.0);
+  });
+
+  test("STEP は T032 (ZOOM_STEP=0.1) と一致する", () => {
+    // Review #6: ボタン増分が T032 と揃っていることを明示的にガード
+    expect(MERMAID_ZOOM_STEP).toBe(0.1);
+  });
+});
+
+describe("clampMermaidZoom", () => {
+  test("MIN 未満は MIN に丸める", () => {
+    expect(clampMermaidZoom(0.3)).toBe(0.5);
+    expect(clampMermaidZoom(0)).toBe(0.5);
+    expect(clampMermaidZoom(-1)).toBe(0.5);
+  });
+
+  test("MAX 超過は MAX に丸める", () => {
+    expect(clampMermaidZoom(4.5)).toBe(4.0);
+    expect(clampMermaidZoom(10)).toBe(4.0);
+  });
+
+  test("範囲内は素通し（wheel 連続値を正規化で丸めない）", () => {
+    expect(clampMermaidZoom(1.0)).toBe(1.0);
+    expect(clampMermaidZoom(1.25)).toBeCloseTo(1.25, 10);
+    expect(clampMermaidZoom(3.7)).toBeCloseTo(3.7, 10);
+  });
+
+  test("境界値 (0.5 / 4.0) はそのまま返る", () => {
+    expect(clampMermaidZoom(0.5)).toBe(0.5);
+    expect(clampMermaidZoom(4.0)).toBe(4.0);
+  });
+
+  test("非有限値 (NaN / Infinity) は DEFAULT / 飽和", () => {
+    expect(clampMermaidZoom(Number.NaN)).toBe(MERMAID_ZOOM_DEFAULT);
+    expect(clampMermaidZoom(Number.POSITIVE_INFINITY)).toBe(MERMAID_ZOOM_MAX);
+    expect(clampMermaidZoom(Number.NEGATIVE_INFINITY)).toBe(MERMAID_ZOOM_MIN);
+  });
+});
+
+describe("wheelDeltaToScaleFactor", () => {
+  test("deltaY=0 で倍率 1.0 (変化なし)", () => {
+    expect(wheelDeltaToScaleFactor(0)).toBe(1.0);
+  });
+
+  test("deltaY<0 で倍率 >1 (拡大)", () => {
+    expect(wheelDeltaToScaleFactor(-10)).toBeGreaterThan(1);
+    expect(wheelDeltaToScaleFactor(-50)).toBeGreaterThan(1);
+  });
+
+  test("deltaY>0 で倍率 <1 (縮小)", () => {
+    expect(wheelDeltaToScaleFactor(10)).toBeLessThan(1);
+    expect(wheelDeltaToScaleFactor(50)).toBeLessThan(1);
+  });
+
+  test("+delta と -delta は逆数の関係 (対称性)", () => {
+    const up = wheelDeltaToScaleFactor(-20);
+    const down = wheelDeltaToScaleFactor(20);
+    expect(up * down).toBeCloseTo(1, 10);
+  });
+
+  test("非有限値は 1.0 (no-op)", () => {
+    expect(wheelDeltaToScaleFactor(Number.NaN)).toBe(1.0);
+    expect(wheelDeltaToScaleFactor(Number.POSITIVE_INFINITY)).toBe(1.0);
+  });
+});
+
+describe("refocusTranslate", () => {
+  test("初期状態 (scale=1, tx=ty=0) で scale=2 へ: focal=(100,50)", () => {
+    const result = refocusTranslate(
+      { scale: 1, tx: 0, ty: 0 },
+      2,
+      100,
+      50,
+    );
+    // focalX - sx * nextScale = 100 - 100 * 2 = -100
+    expect(result.tx).toBe(-100);
+    expect(result.ty).toBe(-50);
+  });
+
+  test("focal-point 不変条件: refocus 後も focal が同じ viewport 位置に載る", () => {
+    // 「screen 上の focal 位置 = tx + sx * scale」が保たれることを確認
+    const prev = { scale: 1, tx: 0, ty: 0 };
+    const focalX = 100;
+    const focalY = 50;
+
+    // 元の画像座標系での focal 位置
+    const origSx = (focalX - prev.tx) / prev.scale;
+    const origSy = (focalY - prev.ty) / prev.scale;
+
+    // scale を 2 倍にする
+    const next = refocusTranslate(prev, 2, focalX, focalY);
+    const newScreenX = next.tx + origSx * 2;
+    const newScreenY = next.ty + origSy * 2;
+
+    expect(newScreenX).toBeCloseTo(focalX, 10);
+    expect(newScreenY).toBeCloseTo(focalY, 10);
+  });
+
+  test("既に translate / scale が入った状態から zoom-in しても focal 不変", () => {
+    const prev = { scale: 1.5, tx: -30, ty: -20 };
+    const focalX = 200;
+    const focalY = 100;
+
+    const origSx = (focalX - prev.tx) / prev.scale;
+    const origSy = (focalY - prev.ty) / prev.scale;
+
+    const next = refocusTranslate(prev, 3.0, focalX, focalY);
+    const newScreenX = next.tx + origSx * 3.0;
+    const newScreenY = next.ty + origSy * 3.0;
+
+    expect(newScreenX).toBeCloseTo(focalX, 10);
+    expect(newScreenY).toBeCloseTo(focalY, 10);
+  });
+
+  test("scale=prev.scale のとき translate 不変 (prev.tx, prev.ty を返す)", () => {
+    const prev = { scale: 2, tx: -50, ty: -30 };
+    const next = refocusTranslate(prev, 2, 100, 80);
+    expect(next.tx).toBeCloseTo(prev.tx, 10);
+    expect(next.ty).toBeCloseTo(prev.ty, 10);
+  });
+});
+
+describe("nextMermaidZoomIn", () => {
+  test("通常ケースで +0.1", () => {
+    expect(nextMermaidZoomIn(1.0)).toBeCloseTo(1.1, 10);
+    expect(nextMermaidZoomIn(0.5)).toBeCloseTo(0.6, 10);
+    expect(nextMermaidZoomIn(3.9)).toBeCloseTo(4.0, 10);
+  });
+
+  test("MAX でクランプ (飽和)", () => {
+    expect(nextMermaidZoomIn(4.0)).toBe(4.0);
+    expect(nextMermaidZoomIn(3.95)).toBe(4.0);
+  });
+
+  test("浮動小数点誤差が累積しない (1.0 → +0.1 を 30 回で 4.0)", () => {
+    let v = 1.0;
+    for (let i = 0; i < 30; i++) {
+      v = nextMermaidZoomIn(v);
+    }
+    expect(v).toBe(4.0);
+  });
+
+  test("増分は MERMAID_ZOOM_STEP に一致する", () => {
+    // Review #6 の検査: STEP 定数と増分の等価性
+    const diff = nextMermaidZoomIn(1.0) - 1.0;
+    expect(diff).toBeCloseTo(MERMAID_ZOOM_STEP, 10);
+  });
+});
+
+describe("nextMermaidZoomOut", () => {
+  test("通常ケースで -0.1", () => {
+    expect(nextMermaidZoomOut(1.0)).toBeCloseTo(0.9, 10);
+    expect(nextMermaidZoomOut(4.0)).toBeCloseTo(3.9, 10);
+    expect(nextMermaidZoomOut(0.6)).toBeCloseTo(0.5, 10);
+  });
+
+  test("MIN でクランプ (飽和)", () => {
+    expect(nextMermaidZoomOut(0.5)).toBe(0.5);
+    expect(nextMermaidZoomOut(0.55)).toBe(0.5);
+  });
+
+  test("浮動小数点誤差が累積しない (4.0 → -0.1 を 35 回で 0.5)", () => {
+    let v = 4.0;
+    for (let i = 0; i < 35; i++) {
+      v = nextMermaidZoomOut(v);
+    }
+    expect(v).toBe(0.5);
+  });
+
+  test("減分は MERMAID_ZOOM_STEP に一致する", () => {
+    const diff = 1.0 - nextMermaidZoomOut(1.0);
+    expect(diff).toBeCloseTo(MERMAID_ZOOM_STEP, 10);
+  });
+});

--- a/src/lib/__tests__/zoom-state.test.ts
+++ b/src/lib/__tests__/zoom-state.test.ts
@@ -1,0 +1,97 @@
+/**
+ * zoom-state.ts のユニットテスト
+ *
+ * clampZoom / nextZoomIn / nextZoomOut の境界値と浮動小数点誤差累積を検証する。
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  ZOOM_MIN,
+  ZOOM_MAX,
+  ZOOM_STEP,
+  ZOOM_DEFAULT,
+  clampZoom,
+  nextZoomIn,
+  nextZoomOut,
+} from "../zoom-state";
+
+describe("定数", () => {
+  test("ZOOM_MIN / MAX / STEP / DEFAULT が仕様値", () => {
+    expect(ZOOM_MIN).toBe(0.5);
+    expect(ZOOM_MAX).toBe(2.0);
+    expect(ZOOM_STEP).toBe(0.1);
+    expect(ZOOM_DEFAULT).toBe(1.0);
+  });
+});
+
+describe("clampZoom", () => {
+  test("MIN 未満は MIN に丸める", () => {
+    expect(clampZoom(0.3)).toBe(0.5);
+    expect(clampZoom(0)).toBe(0.5);
+    expect(clampZoom(-1)).toBe(0.5);
+  });
+
+  test("MAX 超過は MAX に丸める", () => {
+    expect(clampZoom(3)).toBe(2.0);
+    expect(clampZoom(2.5)).toBe(2.0);
+  });
+
+  test("MIN/MAX の範囲内は 0.1 刻みに正規化して素通し", () => {
+    expect(clampZoom(1.0)).toBe(1.0);
+    expect(clampZoom(1.25)).toBe(1.3);
+    expect(clampZoom(0.55)).toBeCloseTo(0.6, 10);
+  });
+
+  test("境界値 (0.5 / 2.0) はそのまま返る", () => {
+    expect(clampZoom(0.5)).toBe(0.5);
+    expect(clampZoom(2.0)).toBe(2.0);
+  });
+
+  test("非有限値 (NaN / Infinity) は DEFAULT に戻す", () => {
+    expect(clampZoom(Number.NaN)).toBe(ZOOM_DEFAULT);
+    expect(clampZoom(Number.POSITIVE_INFINITY)).toBe(ZOOM_MAX);
+    expect(clampZoom(Number.NEGATIVE_INFINITY)).toBe(ZOOM_MIN);
+  });
+});
+
+describe("nextZoomIn", () => {
+  test("通常ケースで +0.1", () => {
+    expect(nextZoomIn(1.0)).toBeCloseTo(1.1, 10);
+    expect(nextZoomIn(0.5)).toBeCloseTo(0.6, 10);
+    expect(nextZoomIn(1.9)).toBeCloseTo(2.0, 10);
+  });
+
+  test("MAX でクランプ (飽和)", () => {
+    expect(nextZoomIn(2.0)).toBe(2.0);
+    expect(nextZoomIn(1.95)).toBe(2.0);
+  });
+
+  test("浮動小数点誤差が累積しない (1.0 → +0.1 を 10 回で 2.0)", () => {
+    let v = 1.0;
+    for (let i = 0; i < 10; i++) {
+      v = nextZoomIn(v);
+    }
+    expect(v).toBe(2.0);
+  });
+});
+
+describe("nextZoomOut", () => {
+  test("通常ケースで -0.1", () => {
+    expect(nextZoomOut(1.0)).toBeCloseTo(0.9, 10);
+    expect(nextZoomOut(2.0)).toBeCloseTo(1.9, 10);
+    expect(nextZoomOut(0.6)).toBeCloseTo(0.5, 10);
+  });
+
+  test("MIN でクランプ (飽和)", () => {
+    expect(nextZoomOut(0.5)).toBe(0.5);
+    expect(nextZoomOut(0.55)).toBe(0.5);
+  });
+
+  test("浮動小数点誤差が累積しない (1.0 → -0.1 を 5 回で 0.5)", () => {
+    let v = 1.0;
+    for (let i = 0; i < 5; i++) {
+      v = nextZoomOut(v);
+    }
+    expect(v).toBe(0.5);
+  });
+});

--- a/src/lib/mermaid-zoom.ts
+++ b/src/lib/mermaid-zoom.ts
@@ -1,0 +1,98 @@
+/**
+ * Mermaid 個別の拡大縮小・パンに使う純粋ヘルパ (T033)。
+ *
+ * WebView 側 (`src/mainview/index.ts`) の `attachMermaidZoom` から呼ばれ、
+ * 各 Mermaid SVG に `transform: translate(tx, ty) scale(s)` を書き戻すための
+ * 値を計算する。DOM には触らない副作用フリーな関数群。
+ *
+ * T032 (`zoom-state.ts`) のパターンを踏襲し、STEP=0.1 で浮動小数点誤差を避ける。
+ * range は T032 の 0.5〜2.0 より広く 0.5〜4.0 とする（個別ズームは詳細確認目的で
+ * 広めを許容 — plan §1.1）。
+ */
+
+export const MERMAID_ZOOM_MIN = 0.5;
+export const MERMAID_ZOOM_MAX = 4.0;
+export const MERMAID_ZOOM_STEP = 0.1;
+export const MERMAID_ZOOM_DEFAULT = 1.0;
+
+/** 0.1 刻みに正規化する（浮動小数点誤差除去）。 */
+function normalize(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+/**
+ * スケールを [MIN, MAX] にクランプする。
+ *
+ * - NaN は DEFAULT に倒す（外部入力由来の事故防止）。
+ * - +Infinity は MAX、-Infinity は MIN へ飽和。
+ * - wheel 由来の連続値を受ける想定なので STEP 正規化はしない。
+ *   （ボタン操作は nextMermaidZoomIn/Out 側で 0.1 刻みにする）
+ */
+export function clampMermaidZoom(value: number): number {
+  if (Number.isNaN(value)) return MERMAID_ZOOM_DEFAULT;
+  if (value >= MERMAID_ZOOM_MAX) return MERMAID_ZOOM_MAX;
+  if (value <= MERMAID_ZOOM_MIN) return MERMAID_ZOOM_MIN;
+  return value;
+}
+
+/**
+ * ホイール / pinch の deltaY を「現在スケールに掛ける倍率」に変換する。
+ *
+ * macOS trackpad pinch は `wheel + ctrlKey=true` として合成され、deltaY は
+ * pinch の 1 フレームあたり ±数〜数十のオーダーで飛んでくる。指数関数ベースに
+ * すれば連続合成しても範囲外へ行きにくく、ズーム感度が倍率に対して自然 (linear
+ * だとスケールが大きいほど敏感に感じる)。
+ *
+ * - deltaY < 0 (pinch-out / scroll-up) → 倍率 > 1 (拡大)
+ * - deltaY > 0 (pinch-in / scroll-down) → 倍率 < 1 (縮小)
+ */
+export function wheelDeltaToScaleFactor(deltaY: number): number {
+  if (!Number.isFinite(deltaY)) return 1.0;
+  // 感度係数: 0.01 で pinch 1 段階 (deltaY≈5) あたり ~5% の変化。手元で試した感触に合わせた値。
+  return Math.exp(-deltaY * 0.01);
+}
+
+/**
+ * focal-point zoom: `(focalX, focalY)` を固定したままスケールを nextScale にした時の
+ * 新しい translate を返す。
+ *
+ * 呼び出し側 (`src/mainview/index.ts`) が T032 の outer CSS `zoom` 補正を済ませた
+ * **local 座標** を渡す責務を負う。ここはその補正後の値を受けて純粋に式を解くだけ。
+ *
+ * 式:
+ * ```
+ *   sx  = (focalX - prev.tx) / prev.scale
+ *   sy  = (focalY - prev.ty) / prev.scale
+ *   tx' = focalX - sx * nextScale
+ *   ty' = focalY - sy * nextScale
+ * ```
+ */
+export function refocusTranslate(
+  prev: { scale: number; tx: number; ty: number },
+  nextScale: number,
+  focalX: number,
+  focalY: number,
+): { tx: number; ty: number } {
+  const sx = (focalX - prev.tx) / prev.scale;
+  const sy = (focalY - prev.ty) / prev.scale;
+  return {
+    tx: focalX - sx * nextScale,
+    ty: focalY - sy * nextScale,
+  };
+}
+
+/** ボタン「+」押下時の次段階スケール（STEP 加算、MAX で飽和）。 */
+export function nextMermaidZoomIn(current: number): number {
+  const next = normalize(current + MERMAID_ZOOM_STEP);
+  if (next >= MERMAID_ZOOM_MAX) return MERMAID_ZOOM_MAX;
+  if (next <= MERMAID_ZOOM_MIN) return MERMAID_ZOOM_MIN;
+  return next;
+}
+
+/** ボタン「−」押下時の次段階スケール（STEP 減算、MIN で飽和）。 */
+export function nextMermaidZoomOut(current: number): number {
+  const next = normalize(current - MERMAID_ZOOM_STEP);
+  if (next >= MERMAID_ZOOM_MAX) return MERMAID_ZOOM_MAX;
+  if (next <= MERMAID_ZOOM_MIN) return MERMAID_ZOOM_MIN;
+  return next;
+}

--- a/src/lib/zoom-state.ts
+++ b/src/lib/zoom-state.ts
@@ -1,0 +1,41 @@
+/**
+ * Markdown 表示領域のズーム倍率を扱う純粋ヘルパ (T032)。
+ *
+ * WebView 側 (`src/mainview/index.ts`) から `.markdown-body` の
+ * CSS `zoom` に書き戻すためだけに使う。DOM には触らない副作用フリーな関数群。
+ *
+ * STEP=0.1 の 10 倍整数化で浮動小数点誤差 (1.0 → +0.1 を 10 回で 1.9999…) を回避する。
+ */
+
+export const ZOOM_MIN = 0.5;
+export const ZOOM_MAX = 2.0;
+export const ZOOM_STEP = 0.1;
+export const ZOOM_DEFAULT = 1.0;
+
+/** 0.1 刻みに正規化する（浮動小数点誤差除去）。 */
+function normalize(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+/**
+ * 倍率を [ZOOM_MIN, ZOOM_MAX] にクランプし、0.1 刻みに正規化する。
+ *
+ * - NaN は ZOOM_DEFAULT に倒す（外部入力由来の事故防止）。
+ * - +Infinity は MAX、-Infinity は MIN へ飽和。
+ */
+export function clampZoom(value: number): number {
+  if (Number.isNaN(value)) return ZOOM_DEFAULT;
+  if (value >= ZOOM_MAX) return ZOOM_MAX;
+  if (value <= ZOOM_MIN) return ZOOM_MIN;
+  return normalize(value);
+}
+
+/** 現在値に STEP を足した倍率（MAX で飽和）。 */
+export function nextZoomIn(current: number): number {
+  return clampZoom(normalize(current + ZOOM_STEP));
+}
+
+/** 現在値から STEP を引いた倍率（MIN で飽和）。 */
+export function nextZoomOut(current: number): number {
+  return clampZoom(normalize(current - ZOOM_STEP));
+}

--- a/src/mainview/index.html
+++ b/src/mainview/index.html
@@ -167,6 +167,82 @@
       margin: 1em 0;
     }
 
+    /* T033: Mermaid 個別ズームのラッパー。
+       `.mermaid` の子として配置され、親の flex 中央揃えに乗る。 */
+    .mermaid-zoom-wrapper {
+      position: relative;
+      overflow: hidden;
+      /* ctrlKey wheel (pinch) のみ preventDefault する運用。
+         iPad / 外部タッチパネル接続時の縦スクロールを守るため pan-y を明示する。 */
+      touch-action: pan-y;
+      max-width: 100%;
+    }
+
+    .mermaid-zoom-wrapper > svg {
+      transform-origin: 0 0;
+      /* pinch 中の focal-point ドリフトを避けるため、transition は基本 off。
+         ボタン操作時のみ JS から一時的に付与する。 */
+      transition: none;
+      will-change: transform;
+      cursor: default;
+      user-select: none;
+    }
+
+    .mermaid-zoom-wrapper.is-zoomed > svg {
+      cursor: grab;
+    }
+    .mermaid-zoom-wrapper.is-panning > svg {
+      cursor: grabbing;
+    }
+
+    .mermaid-zoom-controls {
+      position: absolute;
+      top: 6px;
+      right: 6px;
+      display: none;
+      gap: 4px;
+      background: rgba(255, 255, 255, 0.9);
+      border: 1px solid #d1d9e0;
+      border-radius: 6px;
+      padding: 2px;
+      z-index: 1;
+    }
+    .mermaid-zoom-wrapper:hover .mermaid-zoom-controls,
+    .mermaid-zoom-wrapper:focus-within .mermaid-zoom-controls {
+      display: flex;
+    }
+
+    .mermaid-zoom-controls button {
+      background: transparent;
+      border: none;
+      padding: 4px 8px;
+      cursor: pointer;
+      font: inherit;
+      color: inherit;
+      border-radius: 4px;
+      line-height: 1;
+    }
+    .mermaid-zoom-controls button:hover {
+      background: #eaeef2;
+    }
+    .mermaid-zoom-controls button:focus-visible {
+      outline: 2px solid #0969da;
+      outline-offset: 1px;
+    }
+
+    @media (prefers-color-scheme: dark) {
+      .mermaid-zoom-controls {
+        background: rgba(22, 27, 34, 0.9);
+        border-color: #30363d;
+      }
+      .mermaid-zoom-controls button:hover {
+        background: #21262d;
+      }
+      .mermaid-zoom-controls button:focus-visible {
+        outline-color: #58a6ff;
+      }
+    }
+
     /* Mermaid パースエラーのインライン表示 */
     .mermaid-error {
       background: #fff3cd;

--- a/src/mainview/index.html
+++ b/src/mainview/index.html
@@ -130,6 +130,9 @@
       margin: 0 auto;
       padding: 32px;
       box-sizing: border-box;
+      /* T032: JS (window.__MADO_ZOOM_*) から inline style.zoom で書き換えて拡大縮小する。
+         デフォルトを明示することで DevTools でも初期状態が見える。 */
+      zoom: 1;
     }
 
     /* ダークモード対応 */

--- a/src/mainview/index.ts
+++ b/src/mainview/index.ts
@@ -11,6 +11,16 @@ import hljs from "highlight.js";
 import mermaid from "mermaid";
 import { rewriteImageUrls } from "./rewrite-image-urls";
 import { clampZoom, nextZoomIn, nextZoomOut, ZOOM_DEFAULT } from "../lib/zoom-state";
+import {
+  MERMAID_ZOOM_DEFAULT,
+  MERMAID_ZOOM_MIN,
+  MERMAID_ZOOM_MAX,
+  clampMermaidZoom,
+  nextMermaidZoomIn,
+  nextMermaidZoomOut,
+  refocusTranslate,
+  wheelDeltaToScaleFactor,
+} from "../lib/mermaid-zoom";
 
 // --- marked の設定 ---
 
@@ -173,6 +183,13 @@ async function render(markdownText: string, filePath: string): Promise<void> {
       await mermaid.run({ nodes: validNodes });
     } catch (err) {
       console.error("[mado] mermaid render error:", err);
+    }
+    // attach は try の外。一部の図が throw しても残りの図へ個別ズームを付ける (plan §3.3)。
+    // attachMermaidZoom は svg が見つからないノードを早期 return でスキップする。
+    for (let i = 0; i < validNodes.length; i++) {
+      const node = validNodes[i];
+      if (!node) continue;
+      attachMermaidZoom(node, contentEl, i, validNodes.length);
     }
   }
 
@@ -508,3 +525,252 @@ window.__MADO_ZOOM_RESET__ = (): void => {
 };
 
 console.log("[mado] renderer_started");
+
+// trackpad pinch が届いたことを 1 回だけ記録する状態変化ログ（T033）。
+// 以後は高頻度 wheel ループを発火させないため、同一セッションで 1 回限り。
+let __madoPinchSeen = false;
+document.addEventListener(
+  "wheel",
+  (e) => {
+    if (e.ctrlKey && !__madoPinchSeen) {
+      __madoPinchSeen = true;
+      console.log(`[mado] pinch_detected deltaY=${e.deltaY.toFixed(3)}`);
+    }
+  },
+  { passive: true },
+);
+
+// --- Mermaid 個別ズーム (T033) ---
+
+/** 1 つの Mermaid に紐づくズーム状態 */
+interface MermaidZoomState {
+  scale: number;
+  tx: number;
+  ty: number;
+}
+
+/**
+ * Mermaid `<svg>` に個別の pan/zoom を付与する。
+ *
+ * - `container` (= `<pre class="mermaid">` もしくは mermaid.run 後の置換要素) の子 svg を
+ *   `.mermaid-zoom-wrapper` で包み、overlay に拡大/縮小/リセットボタンを付ける。
+ * - wheel + ctrlKey (trackpad pinch) で focal-point zoom。`ctrlKey` なしの wheel は
+ *   preventDefault しないのでページスクロールは生きる。
+ * - `scale > 1` のとき pointerdown→move でパン可能。threshold 3px 未満はクリック透過。
+ *
+ * focal-point 計算では T032 の outer CSS `zoom` を `getComputedStyle(contentEl).zoom` で
+ * 取得し、`event.clientX/Y - rect` を outerZoom で割って local 座標へ揃える (plan §2.3)。
+ */
+function attachMermaidZoom(
+  container: HTMLElement,
+  contentEl: HTMLElement,
+  index: number,
+  total: number,
+): void {
+  const svg = container.querySelector<SVGElement>("svg");
+  if (!svg) return;
+
+  // Hot Reload / 二重 attach 防止
+  if (container.dataset.madoZoomAttached === "true") return;
+
+  // 1. wrap
+  const wrapper = document.createElement("div");
+  wrapper.className = "mermaid-zoom-wrapper";
+  svg.before(wrapper);
+  wrapper.appendChild(svg);
+
+  // 2. state (クロージャ保持: wrapper ごとに独立)
+  const state: MermaidZoomState = {
+    scale: MERMAID_ZOOM_DEFAULT,
+    tx: 0,
+    ty: 0,
+  };
+
+  const applyTransform = (): void => {
+    svg.style.transform = `translate(${state.tx}px, ${state.ty}px) scale(${state.scale})`;
+    if (state.scale > 1) {
+      wrapper.classList.add("is-zoomed");
+    } else {
+      wrapper.classList.remove("is-zoomed");
+    }
+  };
+
+  /** ボタン操作時だけ短時間 transition を付ける (plan §3.3: pinch 中のドリフト回避) */
+  const withTransientTransition = (apply: () => void): void => {
+    svg.style.transition = "transform 80ms ease-out";
+    apply();
+    setTimeout(() => {
+      svg.style.transition = "";
+    }, 120);
+  };
+
+  /** T032 の outer zoom を DOM から取得（plan §2.3: DOM の真実を優先） */
+  const getOuterZoom = (): number => {
+    const raw = getComputedStyle(contentEl).zoom;
+    const parsed = parseFloat(raw || "1");
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 1;
+  };
+
+  /** ボタン・wheel 共通: scale を変更して transform を反映 */
+  const setScale = (
+    nextScale: number,
+    focalX: number,
+    focalY: number,
+    source: "button" | "wheel" | "pinch",
+  ): void => {
+    const clamped = clampMermaidZoom(nextScale);
+    if (clamped === state.scale) return;
+    const { tx, ty } = refocusTranslate(state, clamped, focalX, focalY);
+    state.scale = clamped;
+    state.tx = tx;
+    state.ty = ty;
+    applyTransform();
+    console.log(
+      `[mado] mermaid_zoom_changed index=${index} scale=${state.scale.toFixed(3)} source=${source}`,
+    );
+  };
+
+  // 3. overlay ボタン
+  const controls = document.createElement("div");
+  controls.className = "mermaid-zoom-controls";
+
+  const makeButton = (label: string, aria: string): HTMLButtonElement => {
+    const b = document.createElement("button");
+    b.type = "button";
+    b.textContent = label;
+    b.setAttribute("aria-label", aria);
+    b.title = aria;
+    return b;
+  };
+
+  const btnIn = makeButton("+", "Mermaid 拡大");
+  const btnOut = makeButton("−", "Mermaid 縮小");
+  const btnReset = makeButton("⟲", "Mermaid リセット");
+
+  btnIn.addEventListener("click", () => {
+    const rect = wrapper.getBoundingClientRect();
+    // ボタン操作時は wrapper 中心を focal とする（カーソル位置よりも自然な UX）
+    const outerZoom = getOuterZoom();
+    const fx = (rect.width / 2) / outerZoom;
+    const fy = (rect.height / 2) / outerZoom;
+    withTransientTransition(() => {
+      setScale(nextMermaidZoomIn(state.scale), fx, fy, "button");
+    });
+  });
+  btnOut.addEventListener("click", () => {
+    const rect = wrapper.getBoundingClientRect();
+    const outerZoom = getOuterZoom();
+    const fx = (rect.width / 2) / outerZoom;
+    const fy = (rect.height / 2) / outerZoom;
+    withTransientTransition(() => {
+      setScale(nextMermaidZoomOut(state.scale), fx, fy, "button");
+    });
+  });
+  btnReset.addEventListener("click", () => {
+    withTransientTransition(() => {
+      state.scale = MERMAID_ZOOM_DEFAULT;
+      state.tx = 0;
+      state.ty = 0;
+      applyTransform();
+      console.log(`[mado] mermaid_zoom_reset index=${index}`);
+    });
+  });
+
+  controls.appendChild(btnIn);
+  controls.appendChild(btnOut);
+  controls.appendChild(btnReset);
+  wrapper.appendChild(controls);
+
+  // 4. wheel (pinch / Ctrl+scroll)
+  wrapper.addEventListener(
+    "wheel",
+    (e: WheelEvent) => {
+      // ctrlKey なしの wheel は通常のページスクロールに任せる (plan §7.4)
+      if (!e.ctrlKey) return;
+      e.preventDefault();
+      const rect = wrapper.getBoundingClientRect();
+      const outerZoom = getOuterZoom();
+      const fx = (e.clientX - rect.left) / outerZoom;
+      const fy = (e.clientY - rect.top) / outerZoom;
+      const factor = wheelDeltaToScaleFactor(e.deltaY);
+      const nextScale = Math.min(
+        MERMAID_ZOOM_MAX,
+        Math.max(MERMAID_ZOOM_MIN, state.scale * factor),
+      );
+      setScale(nextScale, fx, fy, "pinch");
+    },
+    { passive: false },
+  );
+
+  // 5. pan (pointer)
+  let panActive = false;
+  let panStartX = 0;
+  let panStartY = 0;
+  let panLastX = 0;
+  let panLastY = 0;
+  let panMoved = false; // 3px 閾値越え = クリック透過しない
+  const DRAG_THRESHOLD = 3;
+
+  wrapper.addEventListener("pointerdown", (e: PointerEvent) => {
+    if (e.button !== 0) return; // 左クリック以外は無視
+    if (state.scale <= 1) return; // scale=1 ではパン無効 (plan §1.1)
+    // overlay ボタン上では pan を発動しない
+    const target = e.target as Element | null;
+    if (target?.closest(".mermaid-zoom-controls")) return;
+
+    panActive = true;
+    panMoved = false;
+    panStartX = e.clientX;
+    panStartY = e.clientY;
+    panLastX = e.clientX;
+    panLastY = e.clientY;
+    try {
+      wrapper.setPointerCapture(e.pointerId);
+    } catch (err) {
+      console.error("[mado] setPointerCapture failed:", err);
+    }
+  });
+
+  wrapper.addEventListener("pointermove", (e: PointerEvent) => {
+    if (!panActive) return;
+    const dx = e.clientX - panStartX;
+    const dy = e.clientY - panStartY;
+    if (!panMoved && Math.hypot(dx, dy) < DRAG_THRESHOLD) {
+      return; // threshold 未満: クリック透過のため no-op
+    }
+    if (!panMoved) {
+      panMoved = true;
+      wrapper.classList.add("is-panning");
+    }
+    // movementX/Y は WKWebView で不整合の可能性あり → clientX/Y の差分を優先 (plan §9)
+    const stepX = e.clientX - panLastX;
+    const stepY = e.clientY - panLastY;
+    panLastX = e.clientX;
+    panLastY = e.clientY;
+    const outerZoom = getOuterZoom();
+    state.tx += stepX / outerZoom;
+    state.ty += stepY / outerZoom;
+    applyTransform();
+  });
+
+  const endPan = (e: PointerEvent): void => {
+    if (!panActive) return;
+    panActive = false;
+    wrapper.classList.remove("is-panning");
+    try {
+      wrapper.releasePointerCapture(e.pointerId);
+    } catch {
+      // pointerId が既に release 済みのケースは握りつぶす（冪等処理）
+    }
+    if (panMoved) {
+      console.log(
+        `[mado] mermaid_zoom_pan_end index=${index} tx=${state.tx.toFixed(1)} ty=${state.ty.toFixed(1)}`,
+      );
+    }
+  };
+  wrapper.addEventListener("pointerup", endPan);
+  wrapper.addEventListener("pointercancel", endPan);
+
+  container.dataset.madoZoomAttached = "true";
+  console.log(`[mado] mermaid_zoom_attached index=${index} total=${total}`);
+}

--- a/src/mainview/index.ts
+++ b/src/mainview/index.ts
@@ -10,6 +10,7 @@ import { gfmHeadingId } from "marked-gfm-heading-id";
 import hljs from "highlight.js";
 import mermaid from "mermaid";
 import { rewriteImageUrls } from "./rewrite-image-urls";
+import { clampZoom, nextZoomIn, nextZoomOut, ZOOM_DEFAULT } from "../lib/zoom-state";
 
 // --- marked の設定 ---
 
@@ -188,6 +189,14 @@ async function render(markdownText: string, filePath: string): Promise<void> {
   if (mainEl) {
     mainEl.scrollTop = savedScrollY;
   }
+
+  // Hot Reload / ファイル切替時に inline zoom が失われていた場合のフェイルセーフ (T032)。
+  // render() は .markdown-body の innerHTML を差し替えるが要素自体は維持するため
+  // 通常 zoom style は残る。念のため currentZoom が DEFAULT 以外なら再適用する。
+  if (currentZoom !== ZOOM_DEFAULT) {
+    contentEl.style.zoom = String(currentZoom);
+  }
+
   lastRenderedFilePath = filePath;
 }
 
@@ -439,6 +448,12 @@ declare global {
     __MADO_WS_CONNECT__: (port: number) => void;
     /** View メニュー (⌘⌥S) から executeJavascript で呼び出される toggle 関数 */
     __MADO_TOGGLE_SIDEBAR__: () => void;
+    /** View > 拡大 (⌘+) から executeJavascript で呼び出される (T032) */
+    __MADO_ZOOM_IN__: () => void;
+    /** View > 縮小 (⌘-) から executeJavascript で呼び出される (T032) */
+    __MADO_ZOOM_OUT__: () => void;
+    /** View > 実寸 (⌘0) から executeJavascript で呼び出される (T032) */
+    __MADO_ZOOM_RESET__: () => void;
     /** Electrobun のプリロードが提供する host-message 送信関数 */
     __electrobunSendToHost?: (data: unknown) => void;
   }
@@ -455,6 +470,41 @@ window.__MADO_WS_CONNECT__ = (port: number): void => {
 
 window.__MADO_TOGGLE_SIDEBAR__ = (): void => {
   toggleSidebar("menu");
+};
+
+// --- ズーム制御 (T032) ---
+//
+// 計画通り本文コンテナ (`#content` = `article.markdown-body`) の CSS `zoom` を
+// 書き換えることで、サイドバー非影響・Mermaid/コードブロック込みの一括ズームを実現する。
+// 状態はモジュールスコープの currentZoom に保持し、Hot Reload で .markdown-body の
+// innerHTML が差し替わっても要素自体は残るため inline style は維持される想定。
+//
+// DOM 不在（welcome 画面で content が未表示）でも currentZoom は更新される。
+// これは次に .markdown-body が表示された時、CSS デフォルト zoom:1 と state が
+// 一致する限り問題にならない（ZOOM_DEFAULT は 1.0）。別倍率で welcome から
+// 抜けた場合のフェイルセーフとして、render() 終端で inline style を再適用する。
+let currentZoom: number = ZOOM_DEFAULT;
+
+function applyZoom(next: number): void {
+  const clamped = clampZoom(next);
+  if (clamped === currentZoom) return;
+  currentZoom = clamped;
+  // `#content` (= article.markdown-body) を直接取得する。
+  // id の方が「本文コンテナ」という意図に近く、Welcome 時も要素自体は存在する。
+  const el = document.getElementById("content");
+  if (!el) return;
+  el.style.zoom = String(currentZoom);
+  console.log(`[mado] zoom_changed level=${currentZoom}`);
+}
+
+window.__MADO_ZOOM_IN__ = (): void => {
+  applyZoom(nextZoomIn(currentZoom));
+};
+window.__MADO_ZOOM_OUT__ = (): void => {
+  applyZoom(nextZoomOut(currentZoom));
+};
+window.__MADO_ZOOM_RESET__ = (): void => {
+  applyZoom(ZOOM_DEFAULT);
 };
 
 console.log("[mado] renderer_started");


### PR DESCRIPTION
## Summary

- Mermaid ダイアグラム個別の拡大縮小・パンを自前実装 (`transform: translate + scale`、依存追加なし)
- ホバーで右上に `+` / `-` / `⟲` ボタン表示（aria-label、focus-visible 対応、light/dark）
- トラックパッド pinch (wheel + ctrlKey:true) でズーム、カーソル下の focal-point を固定
- ズーム中 (scale > 1) のドラッグで pan、3px 未満はクリック透過
- T032 全体ズームとの合成で `getComputedStyle(contentEl).zoom` を参照し outerZoom 補正
- 通常ホイールスクロールを阻害しない (`touch-action: pan-y` + ctrlKey のときだけ preventDefault)
- 複数 Mermaid が独立にズーム状態保持、Hot Reload で自然にリセット

## Files

- 新規: `src/lib/mermaid-zoom.ts` — DOM 非依存 pure helper (定数 + clamp / wheelDelta / refocus / nextIn / nextOut)
- 新規: `src/lib/__tests__/mermaid-zoom.test.ts` — 24 件 (境界値 + focal-point 不変条件 + STEP 互換ガード)
- 新規: `docs/t033-mermaid-e2e.md` — 手動 E2E 用の Mermaid 3 個サンプル
- 変更: `src/mainview/index.ts` — `attachMermaidZoom` 関数追加、`render()` で attach ループを `mermaid.run` の try 外に配置
- 変更: `src/mainview/index.html` — wrapper / controls CSS、ダークモード、focus-visible outline

## Automated verification

- `bun test`: 250 pass / 0 fail (既存 226 + 新規 24)
- `bunx tsc --noEmit`: T033 由来エラー 0 件 (既存 6 件の負債は別タスク)
- `electrobun build`: バンドル成功

## Test plan (manual E2E — 実機確認が必要)

起動:
```bash
MADO_FILE="$(pwd)/docs/t033-mermaid-e2e.md" bun run build:dev \
  && MADO_FILE="$(pwd)/docs/t033-mermaid-e2e.md" ./node_modules/.bin/electrobun dev
```

### 基本動作
- [ ] hover で右上に `+` / `−` / `⟲` が出現、leave で消える
- [ ] `+` / `−` で拡大縮小、`⟲` で 100% リセット
- [ ] Tab フォーカスで overlay 表示、`focus-visible` outline 視認
- [ ] DevTools で `aria-label="Mermaid 拡大 / 縮小 / リセット"` 確認

### ピンチ・ドラッグ
- [ ] トラックパッド pinch-in/out で拡大縮小、focal-point がカーソル下に追従
- [ ] マウスホイール (Ctrl なし) で通常スクロール、図がズームしない
- [ ] `scale > 1` でドラッグ → pan、`scale === 1` でパン無効

### T032 合成 (最重要)
- [ ] **⌘+ で全体 1.5 倍 → カーソル下に pinch-out → カーソル下の図案要素が動かない** (outerZoom 補正の本丸)
- [ ] ⌘0 で全体リセット時に個別 zoom が保持される

### 独立性 / Hot Reload / エラー
- [ ] `docs/t033-mermaid-e2e.md` の Mermaid 3 個が独立にズーム状態を持つ
- [ ] Markdown 編集保存で Mermaid 再描画 → 個別 zoom リセット (期待動作)
- [ ] `.mermaid-error` の図には overlay が出ない

### ログ
- [ ] 初回 pinch で `[mado] pinch_detected` が 1 回だけ出る

## Fallback 方針

ピンチが `wheel + ctrlKey:true` として届かない、あるいは WKWebView で pointer イベントが期待通り動かない場合は、plan §1.4 のモーダル方式 (Plan B) に切替える。実機 NG の場合はこの PR にコメントを残してください。

## 関連

- Depends on T032 (055d14c feat(T032): add zoom controls for Markdown view)
- Plan: `.team/tasks/033-mermaid/runs/task-033-1777019588/plan.md` (v2 Approved)
- Design Review: `.team/tasks/033-mermaid/runs/task-033-1777019588/design-review.md` (Round 2 Approved)
- Inspection: `.team/tasks/033-mermaid/runs/task-033-1777019588/inspection.md` (GO 条件付き)
- Summary: `.team/tasks/033-mermaid/runs/task-033-1777019588/summary.md`