### PR TITLE
feat: codesign Phase 1 + zoom controls + Why section

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -230,9 +230,12 @@ else
 fi
 ```
 
-### 5. Prod ビルド
+### 5. Prod ビルド（codesign 込み）
 
 ```bash
+# Electrobun が helper / launcher / framework を含めて Developer ID で全署名する。
+# 必要 env: ELECTROBUN_DEVELOPER_ID（"Developer ID Application: ..."）
+# 詳細セットアップ: docs/signing-setup.md
 bun run build:prod
 
 APP_PATH="build/stable-macos-arm64/mado.app"
@@ -241,6 +244,48 @@ if [ ! -d "$APP_PATH" ]; then
   exit 1
 fi
 echo "✅ ビルド成功: $APP_PATH"
+```
+
+### 5.4. 公証 (notarize) — fastlane
+
+Electrobun は codesign のみ実施し、公証は fastlane に外出ししている
+（PEM の path 化を fastlane の app_store_connect_api_key action に任せる構成）。
+`~/git/.envrc` などで `APP_STORE_CONNECT_API_KEY_*` が設定済みである前提。
+
+```bash
+fastlane mac notarize_app || {
+  echo "❌ fastlane notarize_app 失敗"
+  exit 1
+}
+```
+
+`fastlane/Fastfile` の `notarize_app` lane が `.app` と（あれば）`.dmg` の両方を
+公証 + staple する。所要時間は通常 5〜15 分。
+
+### 5.5. 署名・公証検証
+
+1 つでも失敗したらリリース中止。
+
+```bash
+# codesign 検証（deep / strict / 署名チェーン全体）
+codesign --verify --deep --strict --verbose=2 "$APP_PATH" 2>&1 || {
+  echo "❌ codesign 検証失敗"
+  exit 1
+}
+
+# Gatekeeper 評価（Notarized Developer ID であること）
+spctl --assess --type execute --verbose=2 "$APP_PATH" 2>&1 || {
+  echo "❌ Gatekeeper 評価失敗（公証チケットの問題の可能性）"
+  exit 1
+}
+
+# staple 確認（オフラインでも Gatekeeper を通すには staple 済みである必要がある）
+stapler validate "$APP_PATH" || {
+  echo "❌ stapler validate 失敗（notarize が未完了 / staple されていない）"
+  exit 1
+}
+
+echo "✅ 署名・公証・staple 全て OK"
 ```
 
 ### 6. パッケージング
@@ -334,21 +379,31 @@ echo "✅ リリース完了: https://github.com/hummer98/mado/releases/tag/v$NE
 
 ## 注意事項
 
-### unsigned バイナリについて
+### 署名・公証について
 
-mado は現状 codesign / notarize をスキップしている（`electrobun.config.ts` の
-defaultConfig で `codesign: false`, `notarize: false`）。
-エンドユーザーが GitHub Releases からダウンロードした `.zip` には
-quarantine 属性が付くため、初回起動前に以下のいずれかの対応が必要:
+mado は Apple Developer ID Application 証明書で署名し、Apple Notary Service で
+公証（notarize）+ staple 済みのバイナリを配布する。役割分担:
 
-```bash
-# quarantine 属性を削除
-xattr -d com.apple.quarantine /Applications/mado.app
+- **codesign**: Electrobun が担当（`build.mac.codesign: true`）。helper / launcher /
+  framework / dmg を含めて deep に署名する。
+- **notarize + staple**: fastlane が担当（`fastlane/Fastfile` の `notarize_app` lane）。
+  `xcrun notarytool` を呼び、`.app` と `.dmg` を公証して staple する。
+  PEM → `.p8` の path 化は fastlane の `app_store_connect_api_key` action が
+  tempfile で完結処理する（永続化しない）。
 
-# または右クリック → 開く → 「開く」を選択
-```
+ローカル実行時に必要な env（既に `~/git/.envrc` で揃っている前提）:
 
-README / README.ja.md にもエンドユーザー向けの手順として同内容を記載すること。
+| env | 用途 | 取得元 |
+|---|---|---|
+| `ELECTROBUN_DEVELOPER_ID` | codesign identity 文字列 | `security find-identity -p codesigning -v` |
+| `APP_STORE_CONNECT_API_KEY_KEY_ID` | notarize Key ID | App Store Connect |
+| `APP_STORE_CONNECT_API_KEY_ISSUER_ID` | notarize Issuer ID | App Store Connect |
+| `APP_STORE_CONNECT_API_KEY_KEY` | `.p8` の PEM 中身（改行込み） | App Store Connect |
+
+初回セットアップ手順は **`docs/signing-setup.md`** を参照。
+
+CI 上では GitHub Secrets から同等の env を注入する。
+詳細は `docs/release-automation.md` を参照（Phase 2 で整備予定）。
 
 ### リリース失敗時のロールバック
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,26 @@ artifacts/
 # OS
 .DS_Store
 package-lock.json
+
+# Apple codesign / notarize の秘密情報
+# .envrc は direnv 設定（source_up + ローカル固有 env）で個人環境ごとに違う
+.env.local
+.envrc
+*.p8
+*.p12
+*.cer
+
+# fastlane の生成物
+# Fastfile / Appfile / Pluginfile はコミット対象。それ以外の生成物は除外
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots
+fastlane/test_output
+fastlane/README.md
+
+# Bundler
+.bundle/
+vendor/bundle/
+
+# Claude Code 関連
+.claude/scheduled_tasks.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- View メニュー: 拡大 (⌘+) / 縮小 (⌘-) / 実寸 (⌘0) で Markdown 本文を 50%〜200% にズーム (T032)
+
 ## [0.2.0] - 2026-04-21
 
 ### Added

--- a/README.ja.md
+++ b/README.ja.md
@@ -12,6 +12,16 @@
 
 <!-- TODO: スクリーンショット -->
 
+## なぜ作ったか
+
+Markdown エディターは数あれど、AI エージェントとコーディングしていると Markdown 自体を編集する場面はほとんどありません。エディター機能は単に邪魔なのです。かといって VSCode でプレビューを開くのは手間がかかりすぎる。
+
+ブラウザベースのビューワー（localhost 起動型）はいくつもありますが、普段遣いのタブと混ざってしまいます。URL スキームで `open` しても、どのウィンドウ・プロファイルで開くかを制御できません。
+
+GFM と Mermaid v11 をきちんと表示できるビューワーも少なかった。
+
+欲しかったのはシンプルで、「ターミナルから起動できるネイティブウィンドウ」。プロジェクトごとに専用ウィンドウを持ち、作業中はそこに留まる。それだけです。
+
 ## 特長
 
 - **GFM 完全対応** — `marked` + `marked-gfm-heading-id` による GitHub Flavored Markdown
@@ -64,7 +74,6 @@ mado https://...         # URL を開く(将来対応)
 
 mado は [Electrobun](https://electrobun.dev) — [Bun](https://bun.sh) と macOS ネイティブ WKWebView を組み合わせた軽量フレームワーク — の上に構築されています。Bun プロセスが CLI 引数をパースし、ファイルを watch し、WebSocket 経由で WebView に更新を push します。WebView 側では `marked` + `mermaid` が Markdown を描画します。
 
-プロダクト全体のコンセプトとアーキテクチャは [docs/seed.md](./docs/seed.md) を参照してください。
 
 ## 開発
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@
 
 <!-- TODO: screenshot -->
 
+## Why mado?
+
+Markdown editors are everywhere — but when you're coding with an AI agent, you almost never *edit* Markdown. Editor features just get in the way. Opening VS Code for a quick preview feels like overkill.
+
+Browser-based viewers (the localhost kind) are fine, but they mix in with your everyday tabs. Launching one via a URL scheme gives you no control over which window or browser profile catches it.
+
+Most existing viewers also lack proper GFM and Mermaid v11 support.
+
+What I actually wanted: one dedicated native window per project, launched from the terminal, that stays put while I work.
+
 ## Features
 
 - **GFM support** — GitHub Flavored Markdown via `marked` + `marked-gfm-heading-id`
@@ -64,7 +74,6 @@ Changes to the file are detected automatically and the view updates without losi
 
 mado is built on [Electrobun](https://electrobun.dev) — a lightweight framework combining [Bun](https://bun.sh) with the native macOS WKWebView. A thin Bun process parses CLI args, watches the file, and pushes updates over WebSocket to the WebView, which renders Markdown with `marked` + `mermaid`.
 
-See [docs/seed.md](./docs/seed.md) for the full product concept and architecture.
 
 ## Development
 

--- a/docs/signing-setup.md
+++ b/docs/signing-setup.md
@@ -1,0 +1,296 @@
+# Signing & Notarization Setup
+
+mado を Apple Developer ID で署名し、Apple Notary Service で公証して Homebrew
+Cask で配布するための初回セットアップ手順。
+
+- **想定読者**: mado の新規メンテナー、または鍵・証明書・トークンを更新する既存メンテナー
+- **想定頻度**: 基本的に一度きり（鍵の有効期限切れ・紛失時のみ再訪）
+
+## 構成の役割分担
+
+| 工程 | 担当 | 設定箇所 |
+|---|---|---|
+| codesign（helper / launcher / framework / dmg を deep に署名） | **Electrobun** | `electrobun.config.ts` の `build.mac.codesign: true` |
+| `xcrun notarytool submit` + staple | **fastlane** | `fastlane/Fastfile` の `notarize_app` lane |
+| `.p8` の path 化（PEM → tempfile） | **fastlane** | `app_store_connect_api_key` action が自動で tempfile 管理（永続化しない） |
+
+> 「なぜ Electrobun の notarize（`build.mac.notarize: true`）を使わないのか」
+> Electrobun は `ELECTROBUN_APPLEAPIKEYPATH` に **絶対パス** を要求するが、
+> `~/git/.envrc` 等で `APP_STORE_CONNECT_API_KEY_KEY` が PEM 文字列として
+> 定義されているケースだと、PEM → ファイル化を別途運用する必要が出る。
+> fastlane の `app_store_connect_api_key` は PEM 文字列を受け取って内部で
+> tempfile 管理してくれるので、この経路に揃えると `.p8` が disk に永続化されない。
+
+---
+
+## 0. 前提
+
+- macOS 開発機（Apple Silicon 推奨。mado は arm64 のみ build）
+- Xcode Command Line Tools（`xcode-select --install` 済み）
+- `gh` CLI（`gh auth login` 完了）
+- `direnv` 導入済み（`brew install direnv` + シェル統合）
+- `fastlane` 導入済み（`brew install fastlane` または `bundle install`）
+- Apple Developer Program に登録済み
+
+---
+
+## 1. Apple Developer Program — Team ID の確認
+
+1. https://developer.apple.com/account を開く
+2. `Membership details` → `Team ID`
+3. 10 文字の英数字（例: `ABCD1234EF`）を控える
+
+Apple Developer アカウントのホームに `Program License Agreement` 等の同意待ち警告
+が出ていないか確認する（出ていると証明書発行や notarize が拒否される）。
+
+---
+
+## 2. Developer ID Application 証明書の取り込み
+
+公証対象のバイナリは **Developer ID Application** 証明書で署名する必要がある。
+
+### 作成（どちらか一方）
+
+**(a) Xcode から作成（推奨）**
+
+1. Xcode → Settings → Accounts → 対象チームを選択 → `Manage Certificates…`
+2. 左下の `+` → **`Developer ID Application`** を選ぶ
+3. 作成完了すると自動で login keychain に入る
+
+> `Developer ID Application (Managed)` のような **Cloud Managed 証明書は公証に使えない**。
+
+**(b) developer.apple.com から作成（CSR 自前生成）**
+
+Keychain Access の Certificate Assistant で `.certSigningRequest` を生成 → Apple
+Developer Portal にアップロード → `.cer` をダウンロードして login keychain に取り込む。
+
+### 確認 & ELECTROBUN_DEVELOPER_ID 取得
+
+```bash
+security find-identity -v -p codesigning
+```
+
+出力例:
+
+```
+2) B0194F966DEB12B3E605DA9247E0B65062EF4707 "Developer ID Application: Your Name (ABCD123456)"
+```
+
+この **`Developer ID Application: ...` の文字列**全体が `ELECTROBUN_DEVELOPER_ID` の値。
+mado/.envrc などで以下のように export する（後述 §4）:
+
+```bash
+export ELECTROBUN_DEVELOPER_ID="Developer ID Application: Your Name (ABCD123456)"
+```
+
+### `.p12` への書き出し（CI 用、Phase 2 で使用）
+
+GitHub Actions の CI で署名するには証明書を秘密鍵ごと `.p12` に書き出す必要がある。
+
+1. Keychain Access → `login` → `My Certificates` カテゴリ
+2. `Developer ID Application: <Name> (<TEAM>)` を展開し、**証明書と秘密鍵の両方**を選択
+3. 右クリック → `Export 2 items…` → 形式 `Personal Information Exchange (.p12)` で保存
+4. パスワードを設定（後で `DEVELOPER_ID_P12_PASSWORD` Secret に登録）
+
+### 有効期限の管理
+
+Developer ID Application 証明書の有効期限は **5 年**。失効予定日を
+`docs/release-automation.md` に記録しておく。
+
+---
+
+## 3. App Store Connect API Key の発行
+
+`xcrun notarytool` の認証は API Key 方式を採用。
+
+1. https://appstoreconnect.apple.com/access/integrations/api を開く → `Keys` タブ
+2. `Generate API Key` をクリック
+   - Name: `mado Notarize`（任意）
+   - Access: `Developer` 以上（`App Manager` 推奨）
+3. 以下 3 点を控える:
+   - `.p8` ファイル（**ダウンロードは 1 回限り**。紛失したら revoke して再発行）
+   - **Key ID**（10 文字英数字）
+   - **Issuer ID**（UUID 形式）
+
+### env への登録
+
+mado では fastlane の `app_store_connect_api_key` action が以下 3 つの env を自動で
+読み取る。**`~/git/.envrc` 等の親 direnv で既に定義されているなら追加作業は不要**。
+
+| env | 内容 |
+|---|---|
+| `APP_STORE_CONNECT_API_KEY_KEY_ID` | Key ID（10 文字英数字） |
+| `APP_STORE_CONNECT_API_KEY_ISSUER_ID` | Issuer ID（UUID） |
+| `APP_STORE_CONNECT_API_KEY_KEY` | `.p8` ファイルの中身（PEM、改行込み）をそのまま |
+
+未定義の場合は親 direnv（例: `~/git/.envrc`）に追加する:
+
+```bash
+export APP_STORE_CONNECT_API_KEY_KEY_ID="ABCD1234EF"
+export APP_STORE_CONNECT_API_KEY_ISSUER_ID="69a6de7f-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+# .p8 の中身をそのまま埋め込む（heredoc が改行を含めて保持してくれる）
+export APP_STORE_CONNECT_API_KEY_KEY="$(cat <<'EOF'
+-----BEGIN PRIVATE KEY-----
+MIGTAg...全 5 行ほどの PEM...
+-----END PRIVATE KEY-----
+EOF
+)"
+```
+
+> `.p8` ファイル自体をディスクに残したくない場合は、env に PEM を入れた後で
+> `.p8` ファイルを削除しても fastlane の動作には影響しない（fastlane が
+> 起動時に tempfile を再生成する）。
+
+---
+
+## 4. ローカル環境の direnv 設定
+
+### `~/git/.envrc`（親）
+
+`APP_STORE_CONNECT_API_KEY_*` の 3 つ（§3 参照）。`fastlane match` 等を併用している
+場合は他の env と同居していて構わない。
+
+### `mado/.envrc`（プロジェクト）
+
+最低限の構成:
+
+```bash
+source_up
+export ELECTROBUN_DEVELOPER_ID="Developer ID Application: Your Name (ABCD123456)"
+```
+
+`source_up` で親 direnv の `APP_STORE_CONNECT_API_KEY_*` を継承し、
+`ELECTROBUN_DEVELOPER_ID` だけ mado リポジトリ固有として追加する。
+
+設定後:
+
+```bash
+direnv allow
+```
+
+### 確認
+
+```bash
+# 4 つの値（の有無）を確認
+direnv exec . bash -c '
+  for v in ELECTROBUN_DEVELOPER_ID APP_STORE_CONNECT_API_KEY_KEY_ID \
+           APP_STORE_CONNECT_API_KEY_ISSUER_ID APP_STORE_CONNECT_API_KEY_KEY; do
+    test -n "${!v}" && echo "  $v: ✓ set" || echo "  $v: ✗ MISSING"
+  done
+'
+```
+
+### コミットしないファイル
+
+- `.envrc` / `.env*` — direnv 関連は全て `.gitignore` 済み
+- `*.p8` / `*.p12` / `*.cer`
+
+---
+
+## 5. ローカル署名・公証の動作確認
+
+mado は fastlane を `Gemfile` で固定せず、システム / rbenv のグローバル install を
+そのまま使う。`brew install fastlane` または rbenv 環境で `gem install fastlane` 済みなら追加準備不要。
+
+```bash
+# 1. codesign 込みで Prod ビルド（Electrobun が helper / launcher も全署名）
+bun run build:prod
+APP_PATH="build/stable-macos-arm64/mado.app"
+
+# 2. fastlane で公証 + staple（5〜15 分）
+fastlane mac notarize_app
+
+# 3. 検証
+codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+spctl --assess --type execute --verbose=2 "$APP_PATH"
+stapler validate "$APP_PATH"
+
+# 4. 起動スモークテスト
+bash scripts/smoke-test.sh "$APP_PATH"
+```
+
+`spctl --assess` の出力に **`accepted source=Notarized Developer ID`** と出れば
+公証まで全部 OK。
+
+---
+
+## 6. トラブルシューティング
+
+### `security find-identity` に Developer ID Application が出ない
+
+§2 で証明書が login keychain に取り込まれていない。Keychain Access を開き直して
+`My Certificates` カテゴリを確認。
+
+### `Env var ELECTROBUN_DEVELOPER_ID is required to codesign`
+
+direnv が読み込まれていない。`direnv status` で `Loaded RC allowed` が 1 か確認。
+0 なら `direnv allow` を再実行。シェル統合（`eval "$(direnv hook zsh)"`）が
+`.zshrc` / `.bashrc` に入っているかも要確認。
+
+### fastlane の `notarize` が `Invalid` を返す
+
+fastlane は `print_log: true` で notarize log を出す。`xcrun notarytool log <uuid>`
+を手動実行することも可能。よくある原因:
+
+- Hardened Runtime が無効 → `electrobun.config.ts` の entitlements を確認
+- 依存バイナリが未署名 → `codesign --verify --deep` の verbose 出力で詳細確認
+- `bundle_id` が `electrobun.config.ts` の `app.identifier` と不一致
+
+### `stapler staple` が `Could not validate ticket`
+
+Apple CDN への反映待ち。1〜2 分後に `xcrun stapler staple "$APP_PATH"` を再実行。
+
+### `bundle exec fastlane` で「Could not find fastlane」
+
+`bundle install --path vendor/bundle` をまず実行する。`vendor/bundle` は
+`.gitignore` 済み。
+
+---
+
+## 7. 失効・紛失時の対応
+
+| 事象 | 対応 |
+|---|---|
+| Developer ID Application 証明書の失効（5 年） | §2 を再実行。`mado/.envrc` の `ELECTROBUN_DEVELOPER_ID` を更新 |
+| Apple Developer Program の年次更新失念 | 年会費を払って復活、証明書も自動で再有効化 |
+| `.p8` 紛失 | App Store Connect で revoke → 新規発行（§3）。`~/git/.envrc` の `APP_STORE_CONNECT_API_KEY_*` を更新 |
+| `.p8` 流出疑い | 即 revoke + 新規発行 |
+
+---
+
+## 8. （Phase 2 で実施）GitHub Secrets の登録
+
+CI 側の設定は Phase 2（`.github/workflows/build-release.yml` 作成時）に行う。
+登録予定の Secret:
+
+| Secret | 内容 | 取得元 |
+|--------|------|--------|
+| `ELECTROBUN_DEVELOPER_ID` | `"Developer ID Application: ..."` 文字列 | §2 |
+| `DEVELOPER_ID_P12_BASE64` | `.p12` を `base64 -i` した文字列 | §2 |
+| `DEVELOPER_ID_P12_PASSWORD` | `.p12` エクスポート時のパスワード | §2 |
+| `APP_STORE_CONNECT_API_KEY_KEY_ID` | API Key ID | §3 |
+| `APP_STORE_CONNECT_API_KEY_ISSUER_ID` | Issuer ID | §3 |
+| `APP_STORE_CONNECT_API_KEY_KEY` | `.p8` の中身（PEM） | §3 |
+| `KEYCHAIN_PASSWORD` | CI 一時 keychain 用 | `openssl rand -base64 24` |
+| `HOMEBREW_TAP_TOKEN` | tap 自動更新用 | 既存 |
+
+CI 詳細は `docs/release-automation.md` および `.github/workflows/build-release.yml`
+（Phase 2 で追加）を参照。
+
+---
+
+## Appendix: 必要 env の早見表
+
+ローカル mado ビルド時に必要な 4 変数:
+
+| env | 配置場所 | 用途 |
+|---|---|---|
+| `ELECTROBUN_DEVELOPER_ID` | `mado/.envrc`（mado 固有） | Electrobun が codesign 実行時に参照 |
+| `APP_STORE_CONNECT_API_KEY_KEY_ID` | `~/git/.envrc` などの親（fastlane 共通） | fastlane の `app_store_connect_api_key` action |
+| `APP_STORE_CONNECT_API_KEY_ISSUER_ID` | 〃 | 〃 |
+| `APP_STORE_CONNECT_API_KEY_KEY` | 〃 | 〃 (PEM 中身そのまま) |
+
+参照箇所:
+- Electrobun の codesign 実装: `node_modules/electrobun/src/cli/index.ts:4430`
+- fastlane の notarize action: `fastlane action notarize` で確認可能
+- mado の Fastfile: [`../fastlane/Fastfile`](../fastlane/Fastfile)

--- a/electrobun.config.ts
+++ b/electrobun.config.ts
@@ -3,7 +3,7 @@ import type { ElectrobunConfig } from "electrobun";
 export default {
   app: {
     name: "mado",
-    identifier: "dev.mado.app",
+    identifier: "com.ridgeroot.mado",
     version: "0.2.0",
   },
   runtime: {
@@ -25,6 +25,26 @@ export default {
       // highlight.js: コードブロックのシンタックスハイライト用テーマ
       "node_modules/highlight.js/styles/github.css": "views/mainview/hljs-github.css",
       "node_modules/highlight.js/styles/github-dark.css": "views/mainview/hljs-github-dark.css",
+    },
+    mac: {
+      // codesign: Electrobun が helper / launcher / framework まで全署名する。
+      //   `ELECTROBUN_DEVELOPER_ID` env が必要（"Developer ID Application: ..."）。
+      // notarize: false に固定。公証は Electrobun ではなく fastlane の
+      //   `notarize_app` lane に外出し（fastlane/Fastfile 参照）。
+      //   理由: ~/git/.envrc が fastlane 流の APP_STORE_CONNECT_API_KEY_*
+      //   を持っており、PEM の path 化を fastlane の app_store_connect_api_key
+      //   action に任せると tempfile 管理が完結する。詳細は docs/signing-setup.md。
+      codesign: true,
+      notarize: false,
+      createDmg: true,
+      entitlements: {
+        // Bun runtime の JIT に必要（hardened runtime 下でも JIT を許可）
+        "com.apple.security.cs.allow-jit": true,
+        // bun の動的コード生成に必要
+        "com.apple.security.cs.allow-unsigned-executable-memory": true,
+        // node-gyp 系の動的ライブラリ読み込みに必要
+        "com.apple.security.cs.disable-library-validation": true,
+      },
     },
   },
 } satisfies ElectrobunConfig;

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,66 @@
+# mado fastlane lanes
+#
+# 役割: Electrobun が codesign 済みの .app / .dmg を fastlane の notarize action で
+# Apple Notary Service に提出 → staple する。codesign 自体は Electrobun が helper /
+# launcher / framework を含めて deep に行うため、fastlane では署名しない。
+#
+# 必要な env (~/git/.envrc などで定義済み想定):
+#   APP_STORE_CONNECT_API_KEY_KEY_ID
+#   APP_STORE_CONNECT_API_KEY_ISSUER_ID
+#   APP_STORE_CONNECT_API_KEY_KEY     (PEM の中身そのまま、改行込み)
+#
+# 実行:
+#   bun run build:prod                          # codesign 済み .app と .dmg を生成
+#   bundle exec fastlane mac notarize_app       # 公証 + staple
+#
+# 詳細: docs/signing-setup.md
+
+default_platform(:mac)
+
+# fastlane は実行時に fastlane/ ディレクトリへ cwd を変更するため、
+# プロジェクトルート起点で .app / .dmg を解決する。
+PROJECT_ROOT = File.expand_path("..", __dir__).freeze
+BUNDLE_ID    = "com.ridgeroot.mado"
+DEFAULT_APP  = File.join(PROJECT_ROOT, "build/stable-macos-arm64/mado.app").freeze
+DMG_CANDIDATES = [
+  File.join(PROJECT_ROOT, "artifacts/stable-macos-arm64-mado.dmg"),
+  File.join(PROJECT_ROOT, "build/stable-macos-arm64/mado.dmg"),
+].freeze
+
+platform :mac do
+  desc "Notarize the Electrobun-signed mado.app and dmg"
+  lane :notarize_app do
+    api_key = app_store_connect_api_key(
+      duration: 1200,
+      in_house: false,
+      set_spaceship_token: false,
+    )
+
+    app_path = ENV["MADO_APP_PATH"] || DEFAULT_APP
+    UI.user_error!("App bundle not found: #{app_path}") unless File.directory?(app_path)
+
+    UI.message("Notarizing #{app_path}...")
+    notarize(
+      package: app_path,
+      bundle_id: BUNDLE_ID,
+      api_key: api_key,
+      print_log: true,
+    )
+
+    dmg_path = DMG_CANDIDATES.find { |p| File.file?(p) }
+    if dmg_path
+      UI.message("Notarizing #{dmg_path}...")
+      notarize(
+        package: dmg_path,
+        bundle_id: BUNDLE_ID,
+        api_key: api_key,
+        try_early_stapling: true,
+        print_log: true,
+      )
+    else
+      UI.important("No .dmg found in #{DMG_CANDIDATES.join(', ')}; skipping dmg notarization")
+    end
+
+    UI.success("Notarization complete")
+  end
+end

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -22,6 +22,25 @@ if [ ! -x "$LAUNCHER" ]; then
   exit 1
 fi
 
+# 署名検証。`spctl --assess` で「Notarized Developer ID」を検出した場合のみ
+# 詳細検証を行い、それ以外は unsigned / dev ビルドとしてスキップ。
+# `codesign -dv` には Authority 行が含まれないため（`-dvv` 必須）、
+# spctl ベースで判定する方が誤検出が少ない。
+if spctl --assess --type execute --verbose=2 "$APP_PATH" 2>&1 | grep -q "Notarized Developer ID"; then
+  echo "🔐 Notarized Developer ID 署名を検出。検証を実行..."
+  if ! codesign --verify --deep --strict --verbose=2 "$APP_PATH" 2>&1; then
+    echo "❌ codesign 検証失敗"
+    exit 1
+  fi
+  if ! stapler validate "$APP_PATH" 2>&1; then
+    echo "❌ stapler validate 失敗（notarize が未完了 or staple されていない）"
+    exit 1
+  fi
+  echo "✅ 署名・staple 検証 OK"
+else
+  echo "ℹ️  unsigned ビルド（dev または codesign OFF）- 署名検証をスキップ"
+fi
+
 SMOKE_LOG_DIR=$(mktemp -d /tmp/mado-smoke-XXXXXX)
 SMOKE_FILE="$(pwd)/docs/seed.md"
 
@@ -31,24 +50,33 @@ if [ ! -f "$SMOKE_FILE" ]; then
   exit 1
 fi
 
+# Electrobun の launcher は起動時に Resources を self-extracting で更新するため、
+# ビルド成果物の .app に直接 launcher を呼ぶと code signature が壊れて staple
+# ticket が失効する。production 配置（/Applications/mado.app）と同等の独立コピーを
+# 作って起動することで、ビルド成果物の検証可能性を保ったまま起動テストを行う。
+SMOKE_APP_COPY="$SMOKE_LOG_DIR/mado.app"
+ditto "$APP_PATH" "$SMOKE_APP_COPY"
+COPY_LAUNCHER="$SMOKE_APP_COPY/Contents/MacOS/launcher"
+
 echo "📁 ログディレクトリ: $SMOKE_LOG_DIR"
 echo "📄 対象ファイル: $SMOKE_FILE"
+echo "📦 起動用コピー: $SMOKE_APP_COPY"
 
 cleanup() {
   # launcher 経由で起動した bun プロセスを片付ける
-  pkill -f "dev.mado.app" 2>/dev/null || true
+  pkill -f "$SMOKE_APP_COPY" 2>/dev/null || true
   rm -rf "$SMOKE_LOG_DIR"
 }
 trap cleanup EXIT
 
-MADO_LOG_DIR="$SMOKE_LOG_DIR" MADO_FILE="$SMOKE_FILE" "$LAUNCHER" >/dev/null 2>&1 &
+MADO_LOG_DIR="$SMOKE_LOG_DIR" MADO_FILE="$SMOKE_FILE" "$COPY_LAUNCHER" >/dev/null 2>&1 &
 LAUNCHER_PID=$!
 
 # launcher の self-extraction + bun プロセス起動を待つ
 sleep 10
 
-# bun プロセスを停止（ログは既に吐き出されているはず）
-pkill -f "dev.mado.app" 2>/dev/null || true
+# bun プロセスを停止（コピー path で確実に kill する）
+pkill -f "$SMOKE_APP_COPY" 2>/dev/null || true
 wait "$LAUNCHER_PID" 2>/dev/null || true
 
 # ログ確認

--- a/src/bun/index.ts
+++ b/src/bun/index.ts
@@ -756,6 +756,11 @@ async function main(): Promise<void> {
       }
     },
     openFileDialog: (opts) => Utils.openFileDialog(opts),
+    // View メニュー: WebView 側の __MADO_ZOOM_* を呼ぶ (T032)。
+    // ログは WebView 側 applyZoom が出すため Bun 側では二重記録しない。
+    zoomIn: () => win.webview.executeJavascript("window.__MADO_ZOOM_IN__()"),
+    zoomOut: () => win.webview.executeJavascript("window.__MADO_ZOOM_OUT__()"),
+    zoomReset: () => win.webview.executeJavascript("window.__MADO_ZOOM_RESET__()"),
   });
 
   // 10b'. 左ペインファイルエントリ用コンテキストメニューをインストール

--- a/src/bun/menu.test.ts
+++ b/src/bun/menu.test.ts
@@ -10,11 +10,15 @@ import {
   APP_MENU_LABEL,
   FILE_MENU_LABEL,
   EDIT_MENU_LABEL,
+  VIEW_MENU_LABEL,
   WINDOW_MENU_LABEL,
   FILE_OPEN_ACTION,
   FILE_OPEN_RECENT_ACTION,
   APP_PREFERENCES_ACTION,
   WINDOW_FOCUS_ACTION,
+  VIEW_ZOOM_IN_ACTION,
+  VIEW_ZOOM_OUT_ACTION,
+  VIEW_ZOOM_RESET_ACTION,
   ACCELERATOR_QUIT,
   ACCELERATOR_HIDE,
   ACCELERATOR_HIDE_OTHERS,
@@ -22,6 +26,9 @@ import {
   ACCELERATOR_OPEN,
   ACCELERATOR_CLOSE,
   ACCELERATOR_MINIMIZE,
+  ACCELERATOR_ZOOM_IN,
+  ACCELERATOR_ZOOM_OUT,
+  ACCELERATOR_ZOOM_RESET,
   buildApplicationMenu,
   dispatchMenuAction,
 } from "./menu";
@@ -33,6 +40,9 @@ function makeDeps(overrides: Partial<MenuDeps> = {}): MenuDeps {
     listWindows: () => [],
     focusWindowById: () => {},
     openFileDialog: async () => [],
+    zoomIn: () => {},
+    zoomOut: () => {},
+    zoomReset: () => {},
     ...overrides,
   };
 }
@@ -59,17 +69,19 @@ function findByRole(items: MenuItem[], role: string): MenuItem | undefined {
 }
 
 describe("buildApplicationMenu", () => {
-  test("4 つのトップレベルメニュー (mado / File / Edit / Window) を返す", () => {
+  test("5 つのトップレベルメニュー (mado / File / Edit / View / Window) を返す", () => {
     const menu = buildApplicationMenu(makeDeps());
-    expect(menu).toHaveLength(4);
+    expect(menu).toHaveLength(5);
     assertNormal(menu[0]!);
     assertNormal(menu[1]!);
     assertNormal(menu[2]!);
     assertNormal(menu[3]!);
+    assertNormal(menu[4]!);
     expect((menu[0] as { label?: string }).label).toBe(APP_MENU_LABEL);
     expect((menu[1] as { label?: string }).label).toBe(FILE_MENU_LABEL);
     expect((menu[2] as { label?: string }).label).toBe(EDIT_MENU_LABEL);
-    expect((menu[3] as { label?: string }).label).toBe(WINDOW_MENU_LABEL);
+    expect((menu[3] as { label?: string }).label).toBe(VIEW_MENU_LABEL);
+    expect((menu[4] as { label?: string }).label).toBe(WINDOW_MENU_LABEL);
   });
 
   test("Application メニューに role:quit + Cmd+Q accelerator がある", () => {
@@ -137,7 +149,7 @@ describe("buildApplicationMenu", () => {
 
   test("Window メニューに minimize / zoom / bringAllToFront の role が含まれる", () => {
     const menu = buildApplicationMenu(makeDeps());
-    const win = menu[3] as { submenu?: MenuItem[] };
+    const win = menu[4] as { submenu?: MenuItem[] };
     const minimize = findByRole(win.submenu!, "minimize");
     expect(minimize).toBeDefined();
     expect((minimize as { accelerator?: string }).accelerator).toBe(ACCELERATOR_MINIMIZE);
@@ -153,7 +165,7 @@ describe("buildApplicationMenu", () => {
       ],
     });
     const menu = buildApplicationMenu(deps);
-    const win = menu[3] as { submenu?: MenuItem[] };
+    const win = menu[4] as { submenu?: MenuItem[] };
     const sub = win.submenu!;
     const dynamicItems = sub.filter(
       (i) => (i as { action?: string }).action === WINDOW_FOCUS_ACTION,
@@ -169,7 +181,7 @@ describe("buildApplicationMenu", () => {
 
   test("listWindows() が 0 件なら動的項目は展開されない", () => {
     const menu = buildApplicationMenu(makeDeps());
-    const win = menu[3] as { submenu?: MenuItem[] };
+    const win = menu[4] as { submenu?: MenuItem[] };
     const dynamicItems = win.submenu!.filter(
       (i) => (i as { action?: string }).action === WINDOW_FOCUS_ACTION,
     );
@@ -227,6 +239,50 @@ describe("buildApplicationMenu > Edit メニュー", () => {
       "delete",
       "selectAll",
     ]);
+  });
+});
+
+describe("buildApplicationMenu > View メニュー", () => {
+  test("View メニューは menu[3] に存在し VIEW_MENU_LABEL を持つ", () => {
+    const menu = buildApplicationMenu(makeDeps());
+    const view = menu[3] as { label?: string; submenu?: MenuItem[] };
+    expect(view.label).toBe(VIEW_MENU_LABEL);
+    expect(view.submenu).toBeDefined();
+  });
+
+  test("View submenu に 拡大 / 縮小 / 実寸 が正しい順序で並び、action / accelerator が設定される", () => {
+    const menu = buildApplicationMenu(makeDeps());
+    const view = menu[3] as { submenu?: MenuItem[] };
+    const sub = view.submenu!;
+    expect(sub).toHaveLength(3);
+
+    const zoomIn = sub[0] as {
+      label?: string;
+      action?: string;
+      accelerator?: string;
+    };
+    const zoomOut = sub[1] as {
+      label?: string;
+      action?: string;
+      accelerator?: string;
+    };
+    const zoomReset = sub[2] as {
+      label?: string;
+      action?: string;
+      accelerator?: string;
+    };
+
+    expect(zoomIn.label).toBe("拡大");
+    expect(zoomIn.action).toBe(VIEW_ZOOM_IN_ACTION);
+    expect(zoomIn.accelerator).toBe(ACCELERATOR_ZOOM_IN);
+
+    expect(zoomOut.label).toBe("縮小");
+    expect(zoomOut.action).toBe(VIEW_ZOOM_OUT_ACTION);
+    expect(zoomOut.accelerator).toBe(ACCELERATOR_ZOOM_OUT);
+
+    expect(zoomReset.label).toBe("実寸");
+    expect(zoomReset.action).toBe(VIEW_ZOOM_RESET_ACTION);
+    expect(zoomReset.accelerator).toBe(ACCELERATOR_ZOOM_RESET);
   });
 });
 
@@ -301,6 +357,27 @@ describe("dispatchMenuAction", () => {
     });
     await dispatchMenuAction({ action: WINDOW_FOCUS_ACTION, data: {} }, deps);
     expect(focused).toEqual([]);
+  });
+
+  test("view:zoom-in → deps.zoomIn を呼ぶ", async () => {
+    let called = 0;
+    const deps = makeDeps({ zoomIn: () => called++ });
+    await dispatchMenuAction({ action: VIEW_ZOOM_IN_ACTION }, deps);
+    expect(called).toBe(1);
+  });
+
+  test("view:zoom-out → deps.zoomOut を呼ぶ", async () => {
+    let called = 0;
+    const deps = makeDeps({ zoomOut: () => called++ });
+    await dispatchMenuAction({ action: VIEW_ZOOM_OUT_ACTION }, deps);
+    expect(called).toBe(1);
+  });
+
+  test("view:zoom-reset → deps.zoomReset を呼ぶ", async () => {
+    let called = 0;
+    const deps = makeDeps({ zoomReset: () => called++ });
+    await dispatchMenuAction({ action: VIEW_ZOOM_RESET_ACTION }, deps);
+    expect(called).toBe(1);
   });
 
   test("未知 action は何もしない (例外を投げない)", async () => {

--- a/src/bun/menu.ts
+++ b/src/bun/menu.ts
@@ -17,6 +17,7 @@ export const FILE_MENU_LABEL = "File";
 // macOS は "Edit" というラベルを手掛かりに Emoji & Symbols 等を自動挿入するため
 // 英名 "Edit" を固定し、多言語化は別タスクで扱う。
 export const EDIT_MENU_LABEL = "Edit";
+export const VIEW_MENU_LABEL = "View";
 export const WINDOW_MENU_LABEL = "Window";
 
 // --- アクション識別子 ---
@@ -24,6 +25,9 @@ export const FILE_OPEN_ACTION = "file:open";
 export const FILE_OPEN_RECENT_ACTION = "file:open-recent";
 export const APP_PREFERENCES_ACTION = "app:preferences";
 export const WINDOW_FOCUS_ACTION = "window:focus";
+export const VIEW_ZOOM_IN_ACTION = "view:zoom-in";
+export const VIEW_ZOOM_OUT_ACTION = "view:zoom-out";
+export const VIEW_ZOOM_RESET_ACTION = "view:zoom-reset";
 
 // --- アクセラレータ (Electrobun は Swift 側へ文字列をそのまま渡す)。
 // GlobalShortcut.register の例に倣い "CommandOrControl+..." 記法を採用するが、
@@ -35,6 +39,11 @@ export const ACCELERATOR_PREFERENCES = "CommandOrControl+,";
 export const ACCELERATOR_OPEN = "CommandOrControl+O";
 export const ACCELERATOR_CLOSE = "CommandOrControl+W";
 export const ACCELERATOR_MINIMIZE = "CommandOrControl+M";
+// Cmd+"+" は Shift+"=" のため "=" で受ける (Electron/Chromium と同じ慣例)。
+// 動かない場合は "CommandOrControl+Plus" → "CommandOrControl+Equal" の順で試す。
+export const ACCELERATOR_ZOOM_IN = "CommandOrControl+=";
+export const ACCELERATOR_ZOOM_OUT = "CommandOrControl+-";
+export const ACCELERATOR_ZOOM_RESET = "CommandOrControl+0";
 
 // --- メニューラベル (role 既定値があるものはネイティブ側に任せるため未使用) ---
 const LABEL_PREFERENCES = "Preferences...";
@@ -74,6 +83,12 @@ export interface MenuDeps {
     canChooseDirectory?: boolean;
     allowsMultipleSelection?: boolean;
   }) => Promise<string[]>;
+  /** View > 拡大 (⌘+) ハンドラ。WebView 側の __MADO_ZOOM_IN__ を呼ぶ想定。 */
+  zoomIn: () => void;
+  /** View > 縮小 (⌘-) ハンドラ。WebView 側の __MADO_ZOOM_OUT__ を呼ぶ想定。 */
+  zoomOut: () => void;
+  /** View > 実寸 (⌘0) ハンドラ。WebView 側の __MADO_ZOOM_RESET__ を呼ぶ想定。 */
+  zoomReset: () => void;
 }
 
 /**
@@ -170,7 +185,31 @@ export function buildApplicationMenu(deps: MenuDeps): ApplicationMenuItemConfig[
     submenu: windowSubmenu,
   };
 
-  return [appMenu, fileMenu, editMenu, windowMenu];
+  // View メニュー: ⌘+/⌘-/⌘0 で .markdown-body を 50-200% ズーム (T032)。
+  // クリックハンドラは dispatchMenuAction → deps.zoomIn/Out/Reset を経由して
+  // WebView の __MADO_ZOOM_* グローバル関数に到達する。
+  const viewMenu: ApplicationMenuItemConfig = {
+    label: VIEW_MENU_LABEL,
+    submenu: [
+      {
+        label: "拡大",
+        action: VIEW_ZOOM_IN_ACTION,
+        accelerator: ACCELERATOR_ZOOM_IN,
+      },
+      {
+        label: "縮小",
+        action: VIEW_ZOOM_OUT_ACTION,
+        accelerator: ACCELERATOR_ZOOM_OUT,
+      },
+      {
+        label: "実寸",
+        action: VIEW_ZOOM_RESET_ACTION,
+        accelerator: ACCELERATOR_ZOOM_RESET,
+      },
+    ],
+  };
+
+  return [appMenu, fileMenu, editMenu, viewMenu, windowMenu];
 }
 
 /**
@@ -233,6 +272,19 @@ export async function dispatchMenuAction(
       return;
     }
     deps.focusWindowById(event.data.winId);
+    return;
+  }
+
+  if (event.action === VIEW_ZOOM_IN_ACTION) {
+    deps.zoomIn();
+    return;
+  }
+  if (event.action === VIEW_ZOOM_OUT_ACTION) {
+    deps.zoomOut();
+    return;
+  }
+  if (event.action === VIEW_ZOOM_RESET_ACTION) {
+    deps.zoomReset();
     return;
   }
 

--- a/src/lib/__tests__/zoom-state.test.ts
+++ b/src/lib/__tests__/zoom-state.test.ts
@@ -1,0 +1,97 @@
+/**
+ * zoom-state.ts のユニットテスト
+ *
+ * clampZoom / nextZoomIn / nextZoomOut の境界値と浮動小数点誤差累積を検証する。
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  ZOOM_MIN,
+  ZOOM_MAX,
+  ZOOM_STEP,
+  ZOOM_DEFAULT,
+  clampZoom,
+  nextZoomIn,
+  nextZoomOut,
+} from "../zoom-state";
+
+describe("定数", () => {
+  test("ZOOM_MIN / MAX / STEP / DEFAULT が仕様値", () => {
+    expect(ZOOM_MIN).toBe(0.5);
+    expect(ZOOM_MAX).toBe(2.0);
+    expect(ZOOM_STEP).toBe(0.1);
+    expect(ZOOM_DEFAULT).toBe(1.0);
+  });
+});
+
+describe("clampZoom", () => {
+  test("MIN 未満は MIN に丸める", () => {
+    expect(clampZoom(0.3)).toBe(0.5);
+    expect(clampZoom(0)).toBe(0.5);
+    expect(clampZoom(-1)).toBe(0.5);
+  });
+
+  test("MAX 超過は MAX に丸める", () => {
+    expect(clampZoom(3)).toBe(2.0);
+    expect(clampZoom(2.5)).toBe(2.0);
+  });
+
+  test("MIN/MAX の範囲内は 0.1 刻みに正規化して素通し", () => {
+    expect(clampZoom(1.0)).toBe(1.0);
+    expect(clampZoom(1.25)).toBe(1.3);
+    expect(clampZoom(0.55)).toBeCloseTo(0.6, 10);
+  });
+
+  test("境界値 (0.5 / 2.0) はそのまま返る", () => {
+    expect(clampZoom(0.5)).toBe(0.5);
+    expect(clampZoom(2.0)).toBe(2.0);
+  });
+
+  test("非有限値 (NaN / Infinity) は DEFAULT に戻す", () => {
+    expect(clampZoom(Number.NaN)).toBe(ZOOM_DEFAULT);
+    expect(clampZoom(Number.POSITIVE_INFINITY)).toBe(ZOOM_MAX);
+    expect(clampZoom(Number.NEGATIVE_INFINITY)).toBe(ZOOM_MIN);
+  });
+});
+
+describe("nextZoomIn", () => {
+  test("通常ケースで +0.1", () => {
+    expect(nextZoomIn(1.0)).toBeCloseTo(1.1, 10);
+    expect(nextZoomIn(0.5)).toBeCloseTo(0.6, 10);
+    expect(nextZoomIn(1.9)).toBeCloseTo(2.0, 10);
+  });
+
+  test("MAX でクランプ (飽和)", () => {
+    expect(nextZoomIn(2.0)).toBe(2.0);
+    expect(nextZoomIn(1.95)).toBe(2.0);
+  });
+
+  test("浮動小数点誤差が累積しない (1.0 → +0.1 を 10 回で 2.0)", () => {
+    let v = 1.0;
+    for (let i = 0; i < 10; i++) {
+      v = nextZoomIn(v);
+    }
+    expect(v).toBe(2.0);
+  });
+});
+
+describe("nextZoomOut", () => {
+  test("通常ケースで -0.1", () => {
+    expect(nextZoomOut(1.0)).toBeCloseTo(0.9, 10);
+    expect(nextZoomOut(2.0)).toBeCloseTo(1.9, 10);
+    expect(nextZoomOut(0.6)).toBeCloseTo(0.5, 10);
+  });
+
+  test("MIN でクランプ (飽和)", () => {
+    expect(nextZoomOut(0.5)).toBe(0.5);
+    expect(nextZoomOut(0.55)).toBe(0.5);
+  });
+
+  test("浮動小数点誤差が累積しない (1.0 → -0.1 を 5 回で 0.5)", () => {
+    let v = 1.0;
+    for (let i = 0; i < 5; i++) {
+      v = nextZoomOut(v);
+    }
+    expect(v).toBe(0.5);
+  });
+});

--- a/src/lib/zoom-state.ts
+++ b/src/lib/zoom-state.ts
@@ -1,0 +1,41 @@
+/**
+ * Markdown 表示領域のズーム倍率を扱う純粋ヘルパ (T032)。
+ *
+ * WebView 側 (`src/mainview/index.ts`) から `.markdown-body` の
+ * CSS `zoom` に書き戻すためだけに使う。DOM には触らない副作用フリーな関数群。
+ *
+ * STEP=0.1 の 10 倍整数化で浮動小数点誤差 (1.0 → +0.1 を 10 回で 1.9999…) を回避する。
+ */
+
+export const ZOOM_MIN = 0.5;
+export const ZOOM_MAX = 2.0;
+export const ZOOM_STEP = 0.1;
+export const ZOOM_DEFAULT = 1.0;
+
+/** 0.1 刻みに正規化する（浮動小数点誤差除去）。 */
+function normalize(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+/**
+ * 倍率を [ZOOM_MIN, ZOOM_MAX] にクランプし、0.1 刻みに正規化する。
+ *
+ * - NaN は ZOOM_DEFAULT に倒す（外部入力由来の事故防止）。
+ * - +Infinity は MAX、-Infinity は MIN へ飽和。
+ */
+export function clampZoom(value: number): number {
+  if (Number.isNaN(value)) return ZOOM_DEFAULT;
+  if (value >= ZOOM_MAX) return ZOOM_MAX;
+  if (value <= ZOOM_MIN) return ZOOM_MIN;
+  return normalize(value);
+}
+
+/** 現在値に STEP を足した倍率（MAX で飽和）。 */
+export function nextZoomIn(current: number): number {
+  return clampZoom(normalize(current + ZOOM_STEP));
+}
+
+/** 現在値から STEP を引いた倍率（MIN で飽和）。 */
+export function nextZoomOut(current: number): number {
+  return clampZoom(normalize(current - ZOOM_STEP));
+}

--- a/src/mainview/index.html
+++ b/src/mainview/index.html
@@ -130,6 +130,9 @@
       margin: 0 auto;
       padding: 32px;
       box-sizing: border-box;
+      /* T032: JS (window.__MADO_ZOOM_*) から inline style.zoom で書き換えて拡大縮小する。
+         デフォルトを明示することで DevTools でも初期状態が見える。 */
+      zoom: 1;
     }
 
     /* ダークモード対応 */

--- a/src/mainview/index.ts
+++ b/src/mainview/index.ts
@@ -10,6 +10,7 @@ import { gfmHeadingId } from "marked-gfm-heading-id";
 import hljs from "highlight.js";
 import mermaid from "mermaid";
 import { rewriteImageUrls } from "./rewrite-image-urls";
+import { clampZoom, nextZoomIn, nextZoomOut, ZOOM_DEFAULT } from "../lib/zoom-state";
 
 // --- marked の設定 ---
 
@@ -188,6 +189,14 @@ async function render(markdownText: string, filePath: string): Promise<void> {
   if (mainEl) {
     mainEl.scrollTop = savedScrollY;
   }
+
+  // Hot Reload / ファイル切替時に inline zoom が失われていた場合のフェイルセーフ (T032)。
+  // render() は .markdown-body の innerHTML を差し替えるが要素自体は維持するため
+  // 通常 zoom style は残る。念のため currentZoom が DEFAULT 以外なら再適用する。
+  if (currentZoom !== ZOOM_DEFAULT) {
+    contentEl.style.zoom = String(currentZoom);
+  }
+
   lastRenderedFilePath = filePath;
 }
 
@@ -439,6 +448,12 @@ declare global {
     __MADO_WS_CONNECT__: (port: number) => void;
     /** View メニュー (⌘⌥S) から executeJavascript で呼び出される toggle 関数 */
     __MADO_TOGGLE_SIDEBAR__: () => void;
+    /** View > 拡大 (⌘+) から executeJavascript で呼び出される (T032) */
+    __MADO_ZOOM_IN__: () => void;
+    /** View > 縮小 (⌘-) から executeJavascript で呼び出される (T032) */
+    __MADO_ZOOM_OUT__: () => void;
+    /** View > 実寸 (⌘0) から executeJavascript で呼び出される (T032) */
+    __MADO_ZOOM_RESET__: () => void;
     /** Electrobun のプリロードが提供する host-message 送信関数 */
     __electrobunSendToHost?: (data: unknown) => void;
   }
@@ -455,6 +470,41 @@ window.__MADO_WS_CONNECT__ = (port: number): void => {
 
 window.__MADO_TOGGLE_SIDEBAR__ = (): void => {
   toggleSidebar("menu");
+};
+
+// --- ズーム制御 (T032) ---
+//
+// 計画通り本文コンテナ (`#content` = `article.markdown-body`) の CSS `zoom` を
+// 書き換えることで、サイドバー非影響・Mermaid/コードブロック込みの一括ズームを実現する。
+// 状態はモジュールスコープの currentZoom に保持し、Hot Reload で .markdown-body の
+// innerHTML が差し替わっても要素自体は残るため inline style は維持される想定。
+//
+// DOM 不在（welcome 画面で content が未表示）でも currentZoom は更新される。
+// これは次に .markdown-body が表示された時、CSS デフォルト zoom:1 と state が
+// 一致する限り問題にならない（ZOOM_DEFAULT は 1.0）。別倍率で welcome から
+// 抜けた場合のフェイルセーフとして、render() 終端で inline style を再適用する。
+let currentZoom: number = ZOOM_DEFAULT;
+
+function applyZoom(next: number): void {
+  const clamped = clampZoom(next);
+  if (clamped === currentZoom) return;
+  currentZoom = clamped;
+  // `#content` (= article.markdown-body) を直接取得する。
+  // id の方が「本文コンテナ」という意図に近く、Welcome 時も要素自体は存在する。
+  const el = document.getElementById("content");
+  if (!el) return;
+  el.style.zoom = String(currentZoom);
+  console.log(`[mado] zoom_changed level=${currentZoom}`);
+}
+
+window.__MADO_ZOOM_IN__ = (): void => {
+  applyZoom(nextZoomIn(currentZoom));
+};
+window.__MADO_ZOOM_OUT__ = (): void => {
+  applyZoom(nextZoomOut(currentZoom));
+};
+window.__MADO_ZOOM_RESET__ = (): void => {
+  applyZoom(ZOOM_DEFAULT);
 };
 
 console.log("[mado] renderer_started");


### PR DESCRIPTION
## Summary

- **Phase 1 of Apple Developer ID code signing** — Electrobun handles `codesign` (helper / launcher / framework / dmg), fastlane handles `notarize` + `staple` via the `notarize_app` lane. Bundle ID changed from `dev.mado.app` → `com.ridgeroot.mado` to follow reverse-DNS conventions consistent with Team `ridgeroot co.ltd`.
- **Local verification passes**: `spctl --assess` returns `accepted, source=Notarized Developer ID`, both `.app` and `.dmg` are stapled, `scripts/smoke-test.sh` flags the bundle as Notarized Developer ID and the launcher delivers `file_list_added` to a copied bundle (so the original artifact's staple ticket is preserved).
- Carries two pre-existing commits already on the branch:
  - `feat(T032): add zoom controls for Markdown view (Cmd+=/-/0)`
  - `docs: add "Why mado?" section to READMEs`

## Notable design choices

- **fastlane handles notarize, not Electrobun**. `~/git/.envrc` already has `APP_STORE_CONNECT_API_KEY_*` (PEM string). fastlane's `app_store_connect_api_key` action manages the PEM→\`.p8\` tempfile so the key never has to be persisted to disk. Electrobun's `notarize: true` would require a literal `.p8` path, forcing us to invent a tempfile management scheme.
- **smoke-test launches a copy of the .app**. Electrobun's launcher self-extracts into `Contents/Resources/`, which mutates the bundle and invalidates the staple ticket. To keep the build artifact testable, smoke-test \`ditto\`s into \`\$TMPDIR\` before invoking the launcher.
- **Bundle ID picked**: `com.ridgeroot.mado` — reverse-DNS, organization-prefixed (matches the cert's `ridgeroot co.ltd` Team Identifier).

## Files affected

| File | Change |
|---|---|
| `electrobun.config.ts` | `build.mac.codesign: true`, `notarize: false`, entitlements (jit / unsigned-mem / disable-lib-validation), `identifier: "com.ridgeroot.mado"` |
| `fastlane/Fastfile` (new) | `notarize_app` lane — uses `app_store_connect_api_key` + `notarize` for `.app` and `.dmg` |
| `docs/signing-setup.md` (new) | Initial setup guide: cert issuance, ASC API Key, direnv (`source_up`), local verification |
| `.claude/commands/release.md` | New Step 5.4 calls `fastlane mac notarize_app`; Step 5.5 verifies codesign / spctl / stapler |
| `scripts/smoke-test.sh` | spctl-verbose-2-based notarize detection; ditto-copy launcher invocation |
| `.gitignore` | Apple secrets (`*.p8`/`*.p12`/`.envrc`/`.env.local`), fastlane generated files |
| `README.md` / `README.ja.md` | Added "Why mado?" section |

## Out of scope (Phase 2 / 3)

- CI signing in `.github/workflows/build-release.yml` (tracked as Phase 2 tasks)
- Updating `hummer98/homebrew-mado/Casks/mado.rb` to drop the unsigned `caveats` and the `dev.mado.app` zap paths (Phase 2 T-C)
- First signed release (`/release` next minor) — Phase 3
- `<a href>` relative-link handling: see #4

## Test plan

- [x] \`bun test\` — 226 pass / 0 fail
- [x] \`bun run build:prod\` (codesign with Developer ID + Hardened Runtime + Timestamp)
- [x] \`fastlane mac notarize_app\` — \`.app\` and \`.dmg\` notarized + stapled
- [x] \`spctl --assess --type execute --verbose=2\` → \`accepted, source=Notarized Developer ID\`
- [x] \`stapler validate\` — both \`.app\` and \`.dmg\`
- [x] \`scripts/smoke-test.sh\` — \`file_list_added\` detected, build artifact unchanged after run

🤖 Generated with [Claude Code](https://claude.com/claude-code)