### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-29
+
+### Added
+- add Markdown in-page search (T043)
+- add View > Wide Layout toggle (T042)
+- implement File > Open Recent submenu (T041)
+- add ja/en i18n support for menu labels
+- add --version / -v flag to bin/mado
+
+### Changed
+- ci: replace PAT with GitHub App token in update-tap.yml
+- fix(ci): fix url verification check in update-tap.yml
+
+
 ## [0.3.0] - 2026-04-28
 
 ### Added

--- a/electrobun.config.ts
+++ b/electrobun.config.ts
@@ -4,7 +4,7 @@ export default {
   app: {
     name: "mado",
     identifier: "com.ridgeroot.mado",
-    version: "0.3.0",
+    version: "0.4.0",
   },
   runtime: {
     exitOnLastWindowClosed: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mado",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "CLI-first Markdown viewer built with Electrobun",
   "license": "MIT",
   "author": "Yuji Yamamoto",


### PR DESCRIPTION
Bump version to v0.4.0, see CHANGELOG.md for details.