### PR TITLE
fix(ci): build-release が update-tap を起動するよう GitHub App トークン化

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -152,10 +152,23 @@ jobs:
       # tag push 時のみ release を作成。既存 release との衝突は upload --clobber で吸収
       # (CI 二重起動 / retry 時の冪等性確保)。draft / prerelease は使わない
       # (publish しないと update-tap.yml の Homebrew Cask 更新が発火しないため)。
+      # 認証は GITHUB_TOKEN ではなく GitHub App (hummer98-tap-updater) のトークンを使う。
+      # GITHUB_TOKEN 由来の release イベントは他 workflow を起動しない仕様 (無限ループ防止) のため、
+      # update-tap.yml を発火させるには App token で release を作成する必要がある。
+      - name: Generate GitHub App token
+        id: app-token
+        if: github.event_name == 'push'
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          repositories: mado
+          owner: hummer98
+
       - name: Create GitHub Release
         if: github.event_name == 'push'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TAG: ${{ steps.version.outputs.tag }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |


### PR DESCRIPTION
## Summary

- v0.4.0 リリース時、`update-tap.yml` が起動せず Homebrew Cask が 0.3.0 のままになった
- 原因: `build-release.yml` の `Create GitHub Release` ステップが `secrets.GITHUB_TOKEN` を使用していたため、release イベントが他 workflow を起動しない仕様（無限ループ防止）に該当
- 修正: GitHub App `hummer98-tap-updater` のインストールトークンで release を作成するよう切り替え（`update-tap.yml` 既存の同パターンを踏襲）

## 変更内容

- `Create GitHub Release` の直前に `Generate GitHub App token` ステップを追加（`if: github.event_name == 'push'` でガード、`workflow_dispatch` の dry-run 経路では取得しない）
- `Create GitHub Release` の `GH_TOKEN` を `secrets.GITHUB_TOKEN` → `steps.app-token.outputs.token` に差し替え
- 上記の理由をコメントで明記
- `permissions: contents: write` は据え置き（checkout 等の暗黙利用のため）

```yaml
- name: Generate GitHub App token
  id: app-token
  if: github.event_name == 'push'
  uses: actions/create-github-app-token@v1
  with:
    app-id: ${{ secrets.APP_ID }}
    private-key: ${{ secrets.APP_PRIVATE_KEY }}
    repositories: mado
    owner: hummer98
```

## ⚠️ マージ前後に必要なユーザー作業

GitHub App `hummer98-tap-updater` は元々 `homebrew-mado` 用に作られているため、以下が未設定だと次回リリースで失敗する。**マージ前に確認推奨**:

1. **Repository access に `hummer98/mado` を追加**
   - https://github.com/organizations/hummer98/settings/installations → `hummer98-tap-updater` → Configure → Repository access
   - "Only select repositories" の場合、`mado` を追加。"All repositories" なら不要
2. **Permissions に `Contents: Read & Write` を付与**
   - App 設定 → Permissions → Repository permissions → Contents: Read and write
   - 変更後はインストール側で承認 (Review & accept new permissions) が必要になる場合あり
3. **Secrets `APP_ID` / `APP_PRIVATE_KEY` の存在確認**（`update-tap.yml` で既に使われているので存在しているはず）

未設定だと `Generate GitHub App token` が `Resource not accessible by integration` で失敗、または `gh release create` で 403 になる。

## 検証

- `python3 -c "import yaml; yaml.safe_load(...)"` で YAML 構文 OK
- `Upload artifacts (dry-run)` (workflow_dispatch 経路) は無変更
- 実際の効果（release event で `update-tap.yml` が発火するか）は次回 tag push 時に観測する:
  ```bash
  gh run list --repo hummer98/mado --workflow=update-tap.yml --json event,createdAt,status,conclusion --limit 5
  ```
  期待: 直近 run の `event` が `release`、`status=completed`、`conclusion=success`

## 短期回避策（このタスクのスコープ外）

現行 v0.4.0 の Cask は手動で反映可能:
```bash
gh workflow run update-tap.yml --repo hummer98/mado -f tag=v0.4.0
```

## Test plan

- [ ] App 設定（Repository access + Permissions）を確認
- [ ] マージ後、次回リリース（v0.4.1 等）で `update-tap.yml` が `release` イベントで自動起動することを確認
- [ ] 失敗時は `gh run view <run-id>` で `Generate GitHub App token` ステップのログを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)