### PR TITLE
fix(T045): prevent stale highlight residue in in-page search

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,9 @@
         "zod": "^3.24.0",
       },
       "devDependencies": {
+        "@happy-dom/global-registrator": "^20.9.0",
         "@types/bun": "latest",
+        "happy-dom": "^20.9.0",
         "typescript": "^5.0.0",
       },
     },
@@ -35,6 +37,8 @@
     "@chevrotain/types": ["@chevrotain/types@12.0.0", "", {}, "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA=="],
 
     "@chevrotain/utils": ["@chevrotain/utils@12.0.0", "", {}, "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA=="],
+
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.9.0" } }, "sha512-lBW6/m5BIFl3pMuWPNN0lIOYw9LMCmPfix53ExS3FBi4E+NELEljQ3xH6aAV9IYiQRfn9YIIgzzMrD0vIcD7tw=="],
 
     "@iconify/types": ["@iconify/types@2.0.0", "", {}, "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="],
 
@@ -115,6 +119,10 @@
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
+
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@upsetjs/venn.js": ["@upsetjs/venn.js@2.0.0", "", { "optionalDependencies": { "d3-selection": "^3.0.0", "d3-transition": "^3.0.1" } }, "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw=="],
 
@@ -228,6 +236,8 @@
 
     "electrobun": ["electrobun@1.16.0", "", { "dependencies": { "@babylonjs/core": "^7.45.0", "@types/bun": "^1.3.8", "png-to-ico": "^2.1.8", "proxy-agent": "^6.5.0", "rcedit": "^4.0.1", "three": "^0.165.0" }, "bin": { "electrobun": "bin/electrobun.cjs" } }, "sha512-KO/GQO6vpWACJXizqD8F551xtRAgg83Dcfzmjo+6qqCseobttu9x+HL40n+CBnYTe+kBvFXzwso2ZrPuec78zg=="],
 
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
     "escodegen": ["escodegen@2.1.0", "", { "dependencies": { "esprima": "^4.0.1", "estraverse": "^5.2.0", "esutils": "^2.0.2" }, "optionalDependencies": { "source-map": "~0.6.1" }, "bin": { "esgenerate": "bin/esgenerate.js", "escodegen": "bin/escodegen.js" } }, "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w=="],
 
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
@@ -243,6 +253,8 @@
     "github-slugger": ["github-slugger@2.0.0", "", {}, "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="],
 
     "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
+
+    "happy-dom": ["happy-dom@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ=="],
 
     "highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
 
@@ -366,7 +378,11 @@
 
     "vscode-uri": ["vscode-uri@3.1.0", "", {}, "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ=="],
 
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,9 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
+    "@happy-dom/global-registrator": "^20.9.0",
     "@types/bun": "latest",
+    "happy-dom": "^20.9.0",
     "typescript": "^5.0.0"
   }
 }

--- a/src/mainview/__tests__/find.dom.test.ts
+++ b/src/mainview/__tests__/find.dom.test.ts
@@ -1,0 +1,332 @@
+/**
+ * find.ts の DOM 連携層に対する性質テスト (T045)。
+ *
+ * happy-dom 上で `#content` に既知の HTML を流し込み、updateSearch を呼んで
+ * `state.ranges` が指す実テキストと query が一致するか・件数が一貫しているか・
+ * 再検索で前の query のハイライト残留が起きないか を検証する。
+ *
+ * CSS Custom Highlight API は happy-dom 未サポートのため、`Highlight` と
+ * `CSS.highlights` を最小限モックし、Range レベルで検証する。
+ *
+ * Range の textContent 一致は `r.startContainer.nodeValue.slice(r.startOffset, r.endOffset)`
+ * で検証する（`Range.prototype.toString()` の happy-dom 実装齟齬対策、plan §8-1）。
+ */
+
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { GlobalRegistrator } from "@happy-dom/global-registrator";
+
+interface MockHighlight {
+  readonly _ranges: Set<Range>;
+  add(r: Range): MockHighlight;
+  clear(): void;
+  delete(r: Range): boolean;
+  readonly size: number;
+  [Symbol.iterator](): IterableIterator<Range>;
+}
+
+const registry = new Map<string, MockHighlight>();
+const callCounts = {
+  delete: 0,
+  set: 0,
+  highlightConstructed: 0,
+  highlightAdd: 0,
+  highlightClear: 0,
+};
+
+function makeHighlight(initial: ReadonlyArray<Range>): MockHighlight {
+  const ranges = new Set<Range>(initial);
+  const hi: MockHighlight = {
+    _ranges: ranges,
+    add(r: Range): MockHighlight {
+      ranges.add(r);
+      callCounts.highlightAdd++;
+      return hi;
+    },
+    clear(): void {
+      ranges.clear();
+      callCounts.highlightClear++;
+    },
+    delete(r: Range): boolean {
+      return ranges.delete(r);
+    },
+    get size(): number {
+      return ranges.size;
+    },
+    [Symbol.iterator](): IterableIterator<Range> {
+      return ranges.values();
+    },
+  };
+  return hi;
+}
+
+beforeAll((): void => {
+  // happy-dom の正規グローバル登録パスを使用（closest 等の内部 SyntaxError 解決のため）
+  GlobalRegistrator.register();
+
+  // CSS Custom Highlight API のモック（happy-dom 未サポート）
+  const HighlightCtor = function (this: MockHighlight, ...ranges: Range[]): MockHighlight {
+    callCounts.highlightConstructed++;
+    return makeHighlight(ranges);
+  } as unknown as typeof Highlight;
+  Object.defineProperty(globalThis, "Highlight", {
+    value: HighlightCtor,
+    writable: true,
+    configurable: true,
+  });
+
+  interface HighlightsMock {
+    set(name: string, hi: MockHighlight): HighlightsMock;
+    delete(name: string): boolean;
+    has(name: string): boolean;
+    get(name: string): MockHighlight | undefined;
+    clear(): void;
+    readonly size: number;
+    forEach(cb: (v: MockHighlight, k: string) => void): void;
+  }
+  const highlightsMock: HighlightsMock = {
+    set(name: string, hi: MockHighlight): HighlightsMock {
+      registry.set(name, hi);
+      callCounts.set++;
+      return highlightsMock;
+    },
+    delete(name: string): boolean {
+      callCounts.delete++;
+      return registry.delete(name);
+    },
+    has(name: string): boolean {
+      return registry.has(name);
+    },
+    get(name: string): MockHighlight | undefined {
+      return registry.get(name);
+    },
+    clear(): void {
+      registry.clear();
+    },
+    get size(): number {
+      return registry.size;
+    },
+    forEach(cb: (v: MockHighlight, k: string) => void): void {
+      registry.forEach(cb);
+    },
+  };
+  // happy-dom が CSS を read-only で設定するため、defineProperty で上書きする
+  Object.defineProperty(globalThis, "CSS", {
+    value: { highlights: highlightsMock } as unknown as typeof CSS,
+    writable: true,
+    configurable: true,
+  });
+});
+
+afterAll(async (): Promise<void> => {
+  registry.clear();
+  await GlobalRegistrator.unregister();
+});
+
+beforeEach((): void => {
+  registry.clear();
+  callCounts.delete = 0;
+  callCounts.set = 0;
+  callCounts.highlightConstructed = 0;
+  callCounts.highlightAdd = 0;
+  callCounts.highlightClear = 0;
+});
+
+// 動的 import: グローバル DOM/CSS を beforeAll 後に find.ts を import するため
+// import 文ではなく動的 import を使う
+async function loadFindModule(): Promise<typeof import("../find")> {
+  return await import("../find");
+}
+
+function setupContent(html: string): HTMLElement {
+  document.body.innerHTML = `<article id="content">${html}</article>`;
+  const content = document.getElementById("content");
+  if (!content) throw new Error("setup failed: #content not found");
+  return content as HTMLElement;
+}
+
+function rangeText(r: Range): string {
+  const sc = r.startContainer;
+  const v = sc.nodeValue ?? "";
+  return v.slice(r.startOffset, r.endOffset);
+}
+
+describe("updateSearch — Range textContent と query の一致 (Test 1)", () => {
+  test("ハイライト Range の slice 結果が query と完全一致する", async () => {
+    const { __test__ } = await loadFindModule();
+    setupContent(
+      "<p>Markdown editors are everywhere — but <code>everyday</code> tools.</p>",
+    );
+
+    __test__.updateSearch("every");
+
+    // every は "everywhere" の "every" + "everyday" の "every" の 2 箇所
+    expect(__test__.state.ranges.length).toBe(2);
+
+    // 各 Range の slice が "every" と一致することを確認（toString 非依存）
+    for (const r of __test__.state.ranges) {
+      expect(rangeText(r).toLowerCase()).toBe("every");
+    }
+
+    // 結合しても "every".repeat(2) になる
+    const joined = __test__.state.ranges.map((r) => rangeText(r)).join("");
+    expect(joined.toLowerCase()).toBe("every".repeat(2));
+  });
+
+  test("複数テキストノードを跨ぐマッチでも各 slice が query と一致する", async () => {
+    const { __test__ } = await loadFindModule();
+    setupContent(
+      "<p>foo <strong>bar</strong> baz <em>foo</em> qux</p>",
+    );
+
+    __test__.updateSearch("foo");
+
+    expect(__test__.state.ranges.length).toBe(2);
+    for (const r of __test__.state.ranges) {
+      expect(rangeText(r).toLowerCase()).toBe("foo");
+    }
+  });
+});
+
+describe("updateSearch — 件数一貫性 (Test 2)", () => {
+  test("state.ranges.length と #find-count の表示が一致する", async () => {
+    const { __test__ } = await loadFindModule();
+    document.body.innerHTML = `
+      <article id="content"><p>every every every every every every every</p></article>
+      <span id="find-count"></span>
+    `;
+
+    __test__.updateSearch("every");
+
+    expect(__test__.state.ranges.length).toBe(7);
+    const countEl = document.getElementById("find-count");
+    expect(countEl?.textContent).toBe("1 / 7");
+  });
+
+  test("MAX_MATCHES (5000) を超える本文では '5000+' 表記になる", async () => {
+    const { __test__ } = await loadFindModule();
+    // "a" を 6000 個並べる -> ranges.length は 5000 で打ち切り
+    document.body.innerHTML = `
+      <article id="content"><p>${"a".repeat(6000)}</p></article>
+      <span id="find-count"></span>
+    `;
+
+    __test__.updateSearch("a");
+
+    expect(__test__.state.ranges.length).toBe(__test__.MAX_MATCHES);
+    const countEl = document.getElementById("find-count");
+    expect(countEl?.textContent).toBe(`1 / ${__test__.MAX_MATCHES}+`);
+  });
+});
+
+describe("updateSearch — mutation / 再検索 / details (Test 3)", () => {
+  test("innerHTML 差し替え後 resetFind() で state とハイライトがクリアされる", async () => {
+    const { __test__ } = await loadFindModule();
+    document.body.innerHTML = `
+      <article id="content"><p>every every</p></article>
+      <span id="find-count"></span>
+      <input id="find-input" type="text" />
+      <div id="find-box"></div>
+    `;
+
+    __test__.updateSearch("every");
+    expect(__test__.state.ranges.length).toBe(2);
+
+    const content = document.getElementById("content");
+    if (!content) throw new Error("content not found");
+    content.innerHTML = "<p>different content</p>";
+
+    __test__.resetFind();
+
+    expect(__test__.state.ranges).toEqual([]);
+    expect(__test__.state.query).toBe("");
+    expect(__test__.state.isOpen).toBe(false);
+    // T045 修正: singleton Highlight を再利用するため registry には name が残るが、
+    // 中身の Range が 0 件になっていれば描画上は何も表示されない（仕様準拠）。
+    const hi = registry.get(__test__.HIGHLIGHT_ALL);
+    if (hi) {
+      expect([...hi].length).toBe(0);
+    }
+  });
+
+  test("検索 → 再検索 で前の query のハイライトが残らない (回帰テスト本丸)", async () => {
+    const { __test__ } = await loadFindModule();
+    setupContent(
+      // every の短いマッチが多い + everywhere は 1 箇所だけ
+      "<p>every everyone everyday everywhere — and Markdown viewers Electrobun Mermaid.</p>",
+    );
+
+    // 1. 短い query で多数マッチ
+    __test__.updateSearch("every");
+    const everyCount = __test__.state.ranges.length;
+    expect(everyCount).toBeGreaterThanOrEqual(4); // every / everyone / everyday / everywhere の "every"
+    const hiAfterEvery = registry.get(__test__.HIGHLIGHT_ALL);
+    expect(hiAfterEvery).toBeDefined();
+
+    // 2. 長い query で唯一マッチに切り替え
+    __test__.updateSearch("everywhere");
+
+    // state.ranges は "everywhere" 1 件のみ
+    expect(__test__.state.ranges.length).toBe(1);
+    for (const r of __test__.state.ranges) {
+      expect(rangeText(r).toLowerCase()).toBe("everywhere");
+    }
+
+    // ★本丸: CSS.highlights[HIGHLIGHT_ALL] には "everywhere" 以外の Range が
+    //   1 件も残らない（happy-dom 上の論理検証 — WebKit の表示残留は実機で別途確認）
+    const hiAfterEverywhere = registry.get(__test__.HIGHLIGHT_ALL);
+    expect(hiAfterEverywhere).toBeDefined();
+    if (!hiAfterEverywhere) return;
+    const hiRanges = [...hiAfterEverywhere];
+    expect(hiRanges.length).toBe(1);
+    for (const r of hiRanges) {
+      expect(rangeText(r).toLowerCase()).toBe("everywhere");
+    }
+
+    // ★ singleton-identity 表明: 修正後は同一の Highlight インスタンスを clear() + add() で
+    //   再利用するため、CSS.highlights.delete(name) → set(name, new Highlight(...)) という
+    //   WebKit 描画キャッシュ残留の原因となるパターンを取らないことを保証する。
+    //   修正前のコードはこの表明で fail する（毎回 new Highlight を生成して set し直すため）。
+    expect(hiAfterEvery).toBeDefined();
+    if (!hiAfterEvery) return;
+    expect(hiAfterEverywhere).toBe(hiAfterEvery);
+
+    // 3. 段階的縮小: everywhere → every → 空 で残留が起きないことも確認
+    __test__.updateSearch("every");
+    {
+      const hi2 = registry.get(__test__.HIGHLIGHT_ALL);
+      expect(hi2).toBeDefined();
+      if (!hi2) return;
+      // 同じ Highlight インスタンスのままであり続ける
+      expect(hi2).toBe(hiAfterEvery);
+      for (const r of [...hi2]) {
+        expect(rangeText(r).toLowerCase()).toBe("every");
+      }
+    }
+    __test__.updateSearch("");
+    expect(__test__.state.ranges).toEqual([]);
+    // 空 query 時は singleton を空にする（registry から消すか、空のまま残すかは実装裁量）
+    const hiAfterEmpty = registry.get(__test__.HIGHLIGHT_ALL);
+    if (hiAfterEmpty) {
+      expect([...hiAfterEmpty].length).toBe(0);
+    }
+  });
+
+  test("details の open/close を跨いでも Range の指すテキストが query と一致する", async () => {
+    const { __test__ } = await loadFindModule();
+    setupContent(
+      "<details><summary>S</summary><p>everyday tooling</p></details>",
+    );
+    const det = document.querySelector("details") as HTMLDetailsElement | null;
+    if (!det) throw new Error("details not found");
+
+    // details が閉じた状態でも TreeWalker は中身を拾える
+    det.open = false;
+    __test__.updateSearch("every");
+    expect(__test__.state.ranges.length).toBe(1);
+    expect(rangeText(__test__.state.ranges[0]!).toLowerCase()).toBe("every");
+
+    // details を開いても Range の指す位置は変わらない
+    det.open = true;
+    expect(rangeText(__test__.state.ranges[0]!).toLowerCase()).toBe("every");
+  });
+});

--- a/src/mainview/find.ts
+++ b/src/mainview/find.ts
@@ -17,10 +17,13 @@
  * - any 禁止。`unknown` で受けて型ガードで絞る
  */
 
-// TS lib.dom.d.ts に Highlight 型が無い環境への保険。標準と互換のシグネチャ。
+// TS lib.dom.d.ts に Highlight 型が無い環境への保険。標準 (Highlight extends Set<AbstractRange>) と互換のシグネチャ。
 declare class Highlight {
   constructor(...ranges: Range[]);
-  add(range: Range): void;
+  add(range: Range): Highlight;
+  clear(): void;
+  delete(range: Range): boolean;
+  readonly size: number;
 }
 
 // 現行の TS lib.dom.d.ts は HighlightRegistry に forEach しか定義していないため、
@@ -62,6 +65,13 @@ const state: FindState = {
 };
 
 let debounceTimer: number | null = null;
+
+// T045: ハイライト残留対策で同一 Highlight インスタンスを使い回す。
+// `CSS.highlights.delete(name)` → `set(name, new Highlight(...))` の rapid pattern を取ると
+// WebKit の描画キャッシュが前世代の Range を保持して残留ハイライトとなる挙動が観測されたため、
+// 「同じインスタンスを registry に登録したまま `clear()` + `add()` で内容のみ更新する」方針に切り替え。
+let allHighlight: Highlight | null = null;
+let currentHighlight: Highlight | null = null;
 
 const FIND_LABELS = {
   en: {
@@ -180,27 +190,43 @@ function applyHighlights(): void {
     console.warn("[mado] CSS Custom Highlight API unavailable");
     return;
   }
-  CSS.highlights.delete(HIGHLIGHT_ALL);
-  CSS.highlights.delete(HIGHLIGHT_CURRENT);
-  if (state.ranges.length === 0) return;
 
-  // MAX_MATCHES=5000 のスプレッド展開は V8/JSC のスタック上限 (~65535) 内で安全。
-  const allHi = new Highlight(...state.ranges);
-  CSS.highlights.set(HIGHLIGHT_ALL, allHi);
+  // 全マッチ用 Highlight: singleton を再利用して clear()+add() で内容更新 (T045)
+  if (allHighlight === null) {
+    allHighlight = new Highlight();
+  } else {
+    allHighlight.clear();
+  }
+  // 防御的: 外部から CSS.highlights が削除された場合に備えて毎回 has を確認して再登録
+  if (!CSS.highlights.has(HIGHLIGHT_ALL)) {
+    CSS.highlights.set(HIGHLIGHT_ALL, allHighlight);
+  }
+  for (const r of state.ranges) {
+    allHighlight.add(r);
+  }
 
+  // 現在マッチ用 Highlight: 同様に singleton 再利用 (T045)
+  if (currentHighlight === null) {
+    currentHighlight = new Highlight();
+  } else {
+    currentHighlight.clear();
+  }
+  if (!CSS.highlights.has(HIGHLIGHT_CURRENT)) {
+    CSS.highlights.set(HIGHLIGHT_CURRENT, currentHighlight);
+  }
   if (state.currentIndex >= 0 && state.currentIndex < state.ranges.length) {
     const cur = state.ranges[state.currentIndex];
-    if (cur) {
-      const curHi = new Highlight(cur);
-      CSS.highlights.set(HIGHLIGHT_CURRENT, curHi);
-    }
+    if (cur) currentHighlight.add(cur);
   }
 }
 
 function clearHighlights(): void {
   if (!hasHighlightRegistry()) return;
-  CSS.highlights.delete(HIGHLIGHT_ALL);
-  CSS.highlights.delete(HIGHLIGHT_CURRENT);
+  // T045: registry から消すと同じ name の delete/set rapid pattern を再現してしまうため、
+  // 既に保持している singleton を空にするだけにする。registry に空 Highlight が残っても
+  // 描画上は 0 件で何も表示されない（Highlight extends Set の size=0 状態）。
+  if (allHighlight !== null) allHighlight.clear();
+  if (currentHighlight !== null) currentHighlight.clear();
 }
 
 function ensureAncestorsVisible(target: Element): void {
@@ -377,6 +403,22 @@ declare global {
     __MADO_SET_LOCALE__: (locale: FindLocale) => void;
   }
 }
+
+/**
+ * テスト専用 export (T045)。bun:test + happy-dom から DOM 連携部分の振る舞いを
+ * 性質テストで検証するための名前空間。production コードからは参照しない。
+ */
+export const __test__ = {
+  state,
+  updateSearch,
+  closeFind,
+  resetFind,
+  applyHighlights,
+  navigate,
+  HIGHLIGHT_ALL,
+  HIGHLIGHT_CURRENT,
+  MAX_MATCHES,
+} as const;
 
 /**
  * 検索機能を初期化する。index.ts から DOMContentLoaded 後の同期パスで 1 回だけ呼ぶ。


### PR DESCRIPTION
## Summary

In-page search が前世代のハイライトを残留させる WebKit のキャッシュ問題を修正する。`CSS.highlights` で同じ name に対して `delete()` 直後に `set()` を rapid に実行すると WebKit が前世代の Range をペイントキャッシュに残し、検索語と無関係な短いハイライトが画面に残った。Highlight インスタンスを singleton 化して `clear()` + `add()` で内容を更新するパターンに変更する。

再現は task に添付したスクリーンショット参照: `everywhere` 検索時に `everyday` の "every"、`mado` の "m"、`Markdown` の "e" など段階入力 query の世代をまたいだ短いハイライトが残留していた。

## Changes

- \`src/mainview/find.ts\`: \`allHighlight\` / \`currentHighlight\` を singleton 化、\`clear()\` + \`add()\` で更新
- \`src/mainview/__tests__/find.dom.test.ts\` (新規): happy-dom + bun:test で DOM 連携層の性質テストを追加（Test 3-B が修正前 fail / 修正後 pass）

## Test plan

- [x] \`bun test\` 全 279 件 pass
- [x] \`electrobun build\` で dev ビルド成功、bundle に singleton 参照が反映
- [ ] 実機 (\`bun run dev\` + README.md + \`everywhere\` 検索) で目視確認

詳細は \`.team/tasks/045-fix-in-page-search/runs/task-045-1777443784/summary.md\` 参照。

🤖 Generated with [Claude Code](https://claude.com/claude-code)