### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-04-29
+
+### Fixed
+- prevent stale highlight residue in in-page search (T045)
+- build-release が update-tap を起動するよう GitHub App トークン化
+
+### Changed
+- ci(update-tap): switch trigger from release:published to workflow_run
+
+
 ## [0.4.0] - 2026-04-29
 
 ### Added

--- a/electrobun.config.ts
+++ b/electrobun.config.ts
@@ -4,7 +4,7 @@ export default {
   app: {
     name: "mado",
     identifier: "com.ridgeroot.mado",
-    version: "0.4.0",
+    version: "0.4.1",
   },
   runtime: {
     exitOnLastWindowClosed: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mado",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "CLI-first Markdown viewer built with Electrobun",
   "license": "MIT",
   "author": "Yuji Yamamoto",


### PR DESCRIPTION
Bump version to v0.4.1.

## Changes

### Fixed
- prevent stale highlight residue in in-page search (T045)
- build-release が update-tap を起動するよう GitHub App トークン化 (T044)

### Changed
- ci(update-tap): switch trigger from release:published to workflow_run (T040)

See CHANGELOG.md for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)