### PR TITLE
fix(ci): revert App token in build-release.yml to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -152,23 +152,13 @@ jobs:
       # tag push 時のみ release を作成。既存 release との衝突は upload --clobber で吸収
       # (CI 二重起動 / retry 時の冪等性確保)。draft / prerelease は使わない
       # (publish しないと update-tap.yml の Homebrew Cask 更新が発火しないため)。
-      # 認証は GITHUB_TOKEN ではなく GitHub App (hummer98-tap-updater) のトークンを使う。
-      # GITHUB_TOKEN 由来の release イベントは他 workflow を起動しない仕様 (無限ループ防止) のため、
-      # update-tap.yml を発火させるには App token で release を作成する必要がある。
-      - name: Generate GitHub App token
-        id: app-token
-        if: github.event_name == 'push'
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          repositories: mado
-          owner: hummer98
-
+      # update-tap.yml は workflow_run trigger で本 workflow の完了を検知して
+      # 起動するため、release イベントを他 workflow に伝播させる必要は無く
+      # GITHUB_TOKEN で十分。
       - name: Create GitHub Release
         if: github.event_name == 'push'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.version.outputs.tag }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - prevent stale highlight residue in in-page search (T045)
-- build-release が update-tap を起動するよう GitHub App トークン化
 
 ### Changed
-- ci(update-tap): switch trigger from release:published to workflow_run
+- ci(update-tap): switch trigger from release:published to workflow_run, ensuring Homebrew Cask auto-update fires reliably after CI completes
 
 
 ## [0.4.0] - 2026-04-29


### PR DESCRIPTION
T040 で update-tap.yml の trigger を `workflow_run` に変更済みのため、T044 で導入した App token 化は不要（かつ App が mado リポジトリに install されておらず v0.4.1 release を block していた）。GITHUB_TOKEN に戻して update-tap は workflow_run で連鎖発火させる。

CHANGELOG の v0.4.1 から該当行を削除（v0.4.1 release には含まれない fix のため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)