### PR TITLE
chore: release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-05-01
+
 ### Added
 - add `CFBundleDocumentTypes` / `LSItemContentTypes` so Finder lists mado as a Markdown handler (T046)
+
+### Fixed
+- rename build-release workflow to make workflow_run filter match
 
 ## [0.4.1] - 2026-04-29
 

--- a/electrobun.config.ts
+++ b/electrobun.config.ts
@@ -4,7 +4,7 @@ export default {
   app: {
     name: "mado",
     identifier: "com.ridgeroot.mado",
-    version: "0.4.1",
+    version: "0.4.2",
   },
   runtime: {
     exitOnLastWindowClosed: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mado",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "CLI-first Markdown viewer built with Electrobun",
   "license": "MIT",
   "author": "Yuji Yamamoto",


### PR DESCRIPTION
Bump version, see CHANGELOG.md for details.